### PR TITLE
Rewriting state chart and many changes

### DIFF
--- a/Disturbed Dreaming Model.alp
+++ b/Disturbed Dreaming Model.alp
@@ -17,6 +17,9 @@
 			<Id>1590253624667</Id>
 			<Name><![CDATA[Main]]></Name>
 			<ClientAreaTopLeft><X>0</X><Y>0</Y></ClientAreaTopLeft>
+			<Import><![CDATA[import java.util.function.*;]]></Import>
+			<StartupCode><![CDATA[Init();
+CheckInputs();]]></StartupCode>
 			<Generic>false</Generic>
 			<GenericParameter>
 				<Id>1590253624665</Id>
@@ -284,6 +287,46 @@
 						<Type><![CDATA[double]]></Type>        
 					</Properties>
 				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594142480485</Id>
+					<Name><![CDATA[Perseveration]]></Name>
+					<X>610</X><Y>810</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594319601466</Id>
+					<Name><![CDATA[RunHourMostRecentlyAttemptedSleep]]></Name>
+					<X>240</X><Y>1250</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1597079365833</Id>
+					<Name><![CDATA[MostRecentRegimen]]></Name>
+					<Description><![CDATA[0 = Immediate Depotentiate
+1 = Fear Extinction Loop
+2 = NonTraum Nightmare
+3 = Traum Nightmare]]></Description>
+					<X>230</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[int]]></Type>        
+					</Properties>
+				</Variable>
 				<Variable Class="AuxVariable">
 					<Id>1590273961175</Id>
 					<Name><![CDATA[Fear]]></Name>
@@ -293,7 +336,11 @@
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties External="false" Constant="false" Array="false">
-						<Formula><![CDATA[(ImageValence<0.0)?(((AffectDistressTendency+TraumaHistory+(1.0-Control)+ImageDominance+ImageArousal)/5.0)*((NonTraumNMTonight+2.0*TraumNMTonight+NMIntensityLastWeek)/4.0)*(1.0-AdrenalineAntagonists)):0.0]]></Formula>
+						<Formula><![CDATA[(ImageValence<0.0)
+	? ((
+		(AffectDistressTendency+TraumaHistory+(1.0-Control)+ImageDominance+ImageArousal + NonTraumNMTonight+2.0*TraumNMTonight+NMIntensityLastWeek)/9.0)
+			*(1.0-AdrenalineAntagonists))
+		:0.0]]></Formula>
 						<Value><![CDATA[0]]></Value>
 						<Color>-16777216</Color>
 						<Shadow>
@@ -317,7 +364,9 @@
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties External="false" Constant="false" Array="false">
-						<Formula><![CDATA[(ImageValence < 0) ? ((ImageArousal * ImageDominance) + TraumaHistory + NightmareSalience) / 3 * AffectDistressTendency * NMIntensityLastWeek : 0 + 0*NightmareSalience + 0*TreatmentRetraum]]></Formula>
+						<Formula><![CDATA[(ImageValence < 0) ? 
+	((ImageArousal * ImageDominance) + TraumaHistory + NightmareSalience) / 3 
+	* AffectDistressTendency * NMIntensityLastWeek : 0 + 0*NightmareSalience + 0*TreatmentRetraum]]></Formula>
 						<Value><![CDATA[0]]></Value>
 						<Color>-16744320</Color>
 						<Shadow>
@@ -357,7 +406,7 @@
 					<ShowLabel>true</ShowLabel>
 					<Properties External="false" Constant="false" Array="false">
 						<Formula><![CDATA[(ImageValence < 0) ? 
-	((REMDeficitLastWeek + SleepDeficitLastWeek + Perseveration + NightmareDistress + NightmareSalience) / 5)
+	((REMDeficitLastWeek + SleepDeficitLastWeek + calculatePerseveration() + NightmareDistress + NightmareSalience) / 5)
 	 * (1 - AdrenalineAntagonists)
 	 : (0 + 0*TreatmentRetraum)]]></Formula>
 						<Value><![CDATA[0]]></Value>
@@ -390,42 +439,9 @@
 
 				</Variable>
 				<Variable Class="AuxVariable">
-					<Id>1591100309149</Id>
-					<Name><![CDATA[Perseveration]]></Name>
-					<X>990</X><Y>750</Y>
-					<Label><X>-35</X><Y>15</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties External="false" Constant="false" Array="false">
-						<Formula><![CDATA[WorkingMemoryImages > 0 ? ((ImageDominance * ImageArousal) + TraumaHistory)/2 * AffectDistressTendency : 0]]></Formula>
-						<Value><![CDATA[0]]></Value>
-						<Color>-14774017</Color>
-						<Shadow>
-							<Id>1591111183884</Id>
-							<Name><![CDATA[<Perseveration>]]></Name>
-							<X>630</X><Y>810</Y>
-							<Label><X>5</X><Y>0</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<Shadow>
-							<Id>1591189227091</Id>
-							<Name><![CDATA[<Perseveration>]]></Name>
-							<X>370</X><Y>420</Y>
-							<Label><X>5</X><Y>0</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-					</Properties>
-
-				</Variable>
-				<Variable Class="AuxVariable">
 					<Id>1591103848796</Id>
 					<Name><![CDATA[SleepAvoidance]]></Name>
-					<X>990</X><Y>550</Y>
+					<X>1000</X><Y>640</Y>
 					<Label><X>-40</X><Y>-20</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -458,13 +474,13 @@
 				<Variable Class="AuxVariable">
 					<Id>1591109972842</Id>
 					<Name><![CDATA[SleepPressure]]></Name>
-					<X>990</X><Y>450</Y>
+					<X>1000</X><Y>590</Y>
 					<Label><X>-45</X><Y>-20</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>true</ShowLabel>
 					<Properties External="false" Constant="false" Array="false">
-						<Formula><![CDATA[((SleepDeficitLastWeek / (MaxHoursSleepPerNight * 7)) + (REMDeficitLastWeek / (MaxREMCyclesPerNight * 7))) / 2]]></Formula>
+						<Formula><![CDATA[((SleepDeficitLastWeek / 7) + (REMDeficitLastWeek /  7)) / 2]]></Formula>
 						<Value><![CDATA[0]]></Value>
 						<Color>-14774017</Color>
 						<Shadow>
@@ -479,367 +495,6 @@
 					</Properties>
 
 				</Variable>
-				<Variable Class="StockVariable">
-					<Id>1590272595002</Id>
-					<Name><![CDATA[EventMemoryImagesInSleep]]></Name>
-					<X>1300</X><Y>560</Y>
-					<Label><X>-165</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties Array="false">
-					<EquationStyle>classic</EquationStyle>
-					<Width>20</Width>
-					<Height>20</Height>
-						<InitialValue><![CDATA[1]]></InitialValue>
-						<Color/>
-					</Properties>
-				</Variable>
-				<Variable Class="StockVariable">
-					<Id>1590272707106</Id>
-					<Name><![CDATA[RecontextualizedImages]]></Name>
-					<X>1700</X><Y>560</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties Array="false">
-					<EquationStyle>classic</EquationStyle>
-					<Width>20</Width>
-					<Height>20</Height>
-						<Color/>
-					</Properties>
-				</Variable>
-				<Variable Class="StockVariable">
-					<Id>1590272851310</Id>
-					<Name><![CDATA[DepotentiatedImages]]></Name>
-					<X>1700</X><Y>360</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties Array="false">
-					<EquationStyle>classic</EquationStyle>
-					<Width>20</Width>
-					<Height>20</Height>
-						<InitialValue><![CDATA[0]]></InitialValue>
-						<Color/>
-					</Properties>
-				</Variable>
-				<Variable Class="StockVariable">
-					<Id>1590273064457</Id>
-					<Name><![CDATA[WorkingMemoryImages]]></Name>
-					<X>1100</X><Y>660</Y>
-					<Label><X>-115</X><Y>20</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties Array="false">
-					<EquationStyle>classic</EquationStyle>
-					<Width>20</Width>
-					<Height>20</Height>
-						<InitialValue><![CDATA[0]]></InitialValue>
-						<Color/>
-					</Properties>
-				</Variable>
-				<Variable Class="StockVariable">
-					<Id>1590355707137</Id>
-					<Name><![CDATA[AwakeImageAwareness]]></Name>
-					<X>1300</X><Y>760</Y>
-					<Label><X>-140</X><Y>5</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties Array="false">
-					<EquationStyle>classic</EquationStyle>
-					<Width>20</Width>
-					<Height>20</Height>
-						<InitialValue><![CDATA[0]]></InitialValue>
-						<Color/>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1590272730536</Id>
-					<Name><![CDATA[DandRSucceeds]]></Name>
-					<X>1300</X><Y>560</Y>
-					<Label><X>-66</X><Y>22</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SourceId="1590272595002" TargetId="1590272707106" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[(ImageValence < 0) && (AffectLoad > FearExtinctionAttemptThreshold) && (Fear < DandRFailureThreshold) ? 1 : 0]]></Formula>
-						<Color>-256</Color>
-						<Shadow>
-							<Id>1590316084943</Id>
-							<Name><![CDATA[<DandRSucceeds>]]></Name>
-							<X>630</X><Y>390</Y>
-							<Label><X>6</X><Y>1</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>1</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>200</X><Y>0</Y></Point>
-							<Point><X>400</X><Y>0</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1590272858168</Id>
-					<Name><![CDATA[FearExtinctionComplete]]></Name>
-					<X>1700</X><Y>560</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SourceId="1590272707106" TargetId="1590272851310" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[(AffectLoad < FearExtinctionCompletionThreshold) ? 1 : 0]]></Formula>
-						<Color>-16711936</Color>
-						<Shadow>
-							<Id>1590316119123</Id>
-							<Name><![CDATA[<FearExtinctionComplete>]]></Name>
-							<X>630</X><Y>630</Y>
-							<Label><X>6</X><Y>1</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>1</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>0</X><Y>-100</Y></Point>
-							<Point><X>0</X><Y>-200</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1590273070750</Id>
-					<Name><![CDATA[FearExtinctionPartial]]></Name>
-					<X>1700</X><Y>560</Y>
-					<Label><X>-55</X><Y>-15</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SourceId="1590272707106" TargetId="1590272595002" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[1 - (FearExtinctionComplete + FearExtinctionFails)]]></Formula>
-						<Color>-10496</Color>
-						<Shadow>
-							<Id>1590316141567</Id>
-							<Name><![CDATA[<FearExtinctionPartial>]]></Name>
-							<X>630</X><Y>420</Y>
-							<Label><X>6</X><Y>1</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>1</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>-200</X><Y>-100</Y></Point>
-							<Point><X>-400</X><Y>0</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1590273332463</Id>
-					<Name><![CDATA[StartSleep]]></Name>
-					<X>1100</X><Y>660</Y>
-					<Label><X>-70</X><Y>-5</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SourceId="1590273064457" TargetId="1590272595002" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[(HourOfDay > NormalSleepHour) && (SleepAvoidance < SleepPressure) ? 1 : 0]]></Formula>
-						<Color>-14774017</Color>
-						<Shadow>
-							<Id>1590316466437</Id>
-							<Name><![CDATA[<StartSleep>]]></Name>
-							<X>630</X><Y>570</Y>
-							<Label><X>6</X><Y>1</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>1</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>100</X><Y>-50</Y></Point>
-							<Point><X>200</X><Y>-100</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1590273663214</Id>
-					<Name><![CDATA[DandRFails]]></Name>
-					<X>1300</X><Y>560</Y>
-					<Label><X>-44</X><Y>18</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SourceId="1590272595002" TargetId="1590355707137" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[(ImageValence < 0) && (AffectLoad > FearExtinctionAttemptThreshold) && (Fear >= DandRFailureThreshold) ? 1 : 0]]></Formula>
-						<Color>-65281</Color>
-						<Shadow>
-							<Id>1590316182063</Id>
-							<Name><![CDATA[<DandRFails>]]></Name>
-							<X>630</X><Y>480</Y>
-							<Label><X>6</X><Y>1</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>1</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>0</X><Y>100</Y></Point>
-							<Point><X>0</X><Y>200</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1590318693501</Id>
-					<Name><![CDATA[EventMemory]]></Name>
-					<X>1120</X><Y>470</Y>
-					<Label><X>-5</X><Y>-20</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties TargetId="1590272595002" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[0]]></Formula>
-						<Color>-4144960</Color>
-						<Shadow>
-							<Id>1590318988160</Id>
-							<Name><![CDATA[<EventMemory>]]></Name>
-							<X>630</X><Y>360</Y>
-							<Label><X>6</X><Y>1</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>1</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>80</X><Y>40</Y></Point>
-							<Point><X>180</X><Y>90</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1590349895427</Id>
-					<Name><![CDATA[FearExtinctionFails]]></Name>
-					<X>1700</X><Y>560</Y>
-					<Label><X>10</X><Y>2</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SourceId="1590272707106" TargetId="1590355707137" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[(AffectLoad >= FearExtinctionCompletionThreshold) && (Fear > FearExtinctionFailureThreshold) ? 1 : 0]]></Formula>
-						<Color>-65536</Color>
-						<Shadow>
-							<Id>1590350936277</Id>
-							<Name><![CDATA[<FearExtinctionFails>]]></Name>
-							<X>630</X><Y>450</Y>
-							<Label><X>6</X><Y>1</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>2</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>0</X><Y>100</Y></Point>
-							<Point><X>-200</X><Y>200</Y></Point>
-							<Point><X>-400</X><Y>200</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1590355744865</Id>
-					<Name><![CDATA[EndSleep]]></Name>
-					<X>1300</X><Y>760</Y>
-					<Label><X>-65</X><Y>10</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SourceId="1590355707137" TargetId="1590273064457" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[(HoursSleepTonight >= MaxHoursSleepPerNight) || (Fear >= PostNightmareSleepThreshold) ? 1 : 0]]></Formula>
-						<Color>-14774017</Color>
-						<Shadow>
-							<Id>1590356917409</Id>
-							<Name><![CDATA[<EndSleep>]]></Name>
-							<X>630</X><Y>540</Y>
-							<Label><X>6</X><Y>1</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>1</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>-100</X><Y>-50</Y></Point>
-							<Point><X>-200</X><Y>-100</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1590355791892</Id>
-					<Name><![CDATA[RestartDreamingFromAwake]]></Name>
-					<X>1300</X><Y>760</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SourceId="1590355707137" TargetId="1590272595002" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[1 - EndSleep]]></Formula>
-						<Color>-16711681</Color>
-						<Shadow>
-							<Id>1590356880971</Id>
-							<Name><![CDATA[<RestartDreamingFromAwake>]]></Name>
-							<X>630</X><Y>510</Y>
-							<Label><X>7</X><Y>1</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>1</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>200</X><Y>-100</Y></Point>
-							<Point><X>0</X><Y>-200</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
-				<Variable Class="Flow">
-					<Id>1591006489550</Id>
-					<Name><![CDATA[DreamingNoFearExtinction]]></Name>
-					<X>1300</X><Y>560</Y>
-					<Label><X>-160</X><Y>-5</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SourceId="1590272595002" TargetId="1590272851310" External="false" Constant="false" Array="false">
-						<Formula><![CDATA[1 - (DandRFails + DandRSucceeds)]]></Formula>
-						<Color>-16711936</Color>
-						<Shadow>
-							<Id>1591007044220</Id>
-							<Name><![CDATA[<DreamingNoFearExtinction>]]></Name>
-							<X>630</X><Y>600</Y>
-							<Label><X>5</X><Y>0</Y></Label>
-							<PublicFlag>false</PublicFlag>
-							<PresentationFlag>true</PresentationFlag>
-							<ShowLabel>true</ShowLabel>
-						</Shadow>
-						<ValveIndex>2</ValveIndex>
-						<Points>
-							<Point><X>0</X><Y>0</Y></Point>
-							<Point><X>0</X><Y>-100</Y></Point>
-							<Point><X>200</X><Y>-200</Y></Point>
-							<Point><X>400</X><Y>-200</Y></Point>
-						</Points>
-					</Properties>
-				</Variable>
 				<Variable Class="Parameter">
 					<Id>1590272662305</Id>
 					<Name><![CDATA[AffectDistressTendency]]></Name>
@@ -852,6 +507,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.5]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1590272662303</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -873,6 +531,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.5]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1590274024198</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -894,6 +555,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.25]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1590274267531</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -939,6 +603,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.5]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1590347364668</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -960,6 +627,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.5]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1590347366157</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -981,6 +651,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.5]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1590349248373</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1044,6 +717,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1590445337738</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1096,27 +772,6 @@
 					</Properties>                 
 				</Variable>
 				<Variable Class="Parameter">
-					<Id>1590446887199</Id>
-					<Name><![CDATA[FearExtinctionCompletionThreshold]]></Name>
-					<X>230</X><Y>760</Y>
-					<Label><X>-210</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>true</ShowLabel>
-					<Properties SaveInSnapshot="true" ModificatorType="STATIC">
-						<Type><![CDATA[double]]></Type>
-						<UnitType><![CDATA[NONE]]></UnitType>
-						<SdArray>false</SdArray>
-						<ParameterEditor>
-							<Id>1590446887197</Id>
-							<EditorContolType>TEXT_BOX</EditorContolType>
-							<MinSliderValue><![CDATA[0]]></MinSliderValue>
-							<MaxSliderValue><![CDATA[100]]></MaxSliderValue>
-							<DelimeterType>NO_DELIMETER</DelimeterType>
-						</ParameterEditor>
-					</Properties>                 
-				</Variable>
-				<Variable Class="Parameter">
 					<Id>1590680120556</Id>
 					<Name><![CDATA[ImageStabilizationCapacity]]></Name>
 					<X>230</X><Y>450</Y>
@@ -1128,6 +783,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.5]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1590680120554</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1170,6 +828,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.75]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1591034183126</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1191,6 +852,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[4]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1591046767325</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1212,6 +876,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[8]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1591051655410</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1233,6 +900,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[8]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1591095647140</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1254,6 +924,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.005]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1591097977262</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1320,6 +993,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.005]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1591136318402</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1341,6 +1017,9 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.01]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1591136346713</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
@@ -1362,8 +1041,56 @@
 						<Type><![CDATA[double]]></Type>
 						<UnitType><![CDATA[NONE]]></UnitType>
 						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[0.5]]></Code>
+						</DefaultValue>
 						<ParameterEditor>
 							<Id>1591193162219</Id>
+							<EditorContolType>TEXT_BOX</EditorContolType>
+							<MinSliderValue><![CDATA[0]]></MinSliderValue>
+							<MaxSliderValue><![CDATA[100]]></MaxSliderValue>
+							<DelimeterType>NO_DELIMETER</DelimeterType>
+						</ParameterEditor>
+					</Properties>                 
+				</Variable>
+				<Variable Class="Parameter">
+					<Id>1594141524134</Id>
+					<Name><![CDATA[TimeInState]]></Name>
+					<X>230</X><Y>1210</Y>
+					<Label><X>-110</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" ModificatorType="STATIC">
+						<Type><![CDATA[int]]></Type>
+						<UnitType><![CDATA[NONE]]></UnitType>
+						<SdArray>false</SdArray>
+						<DefaultValue Class="CodeValue">
+							<Code><![CDATA[1]]></Code>
+						</DefaultValue>
+						<ParameterEditor>
+							<Id>1594141524132</Id>
+							<EditorContolType>TEXT_BOX</EditorContolType>
+							<MinSliderValue><![CDATA[0]]></MinSliderValue>
+							<MaxSliderValue><![CDATA[100]]></MaxSliderValue>
+							<DelimeterType>NO_DELIMETER</DelimeterType>
+						</ParameterEditor>
+					</Properties>                 
+				</Variable>
+				<Variable Class="Parameter">
+					<Id>1597080388010</Id>
+					<Name><![CDATA[ExperimentId]]></Name>
+					<X>260</X><Y>1420</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" ModificatorType="STATIC">
+						<Type><![CDATA[String]]></Type>
+						<UnitType><![CDATA[NONE]]></UnitType>
+						<SdArray>false</SdArray>
+						<ParameterEditor>
+							<Id>1597080388008</Id>
 							<EditorContolType>TEXT_BOX</EditorContolType>
 							<MinSliderValue><![CDATA[0]]></MinSliderValue>
 							<MaxSliderValue><![CDATA[100]]></MaxSliderValue>
@@ -1551,14 +1278,89 @@
 					</Properties>
 
 				</Variable>
+				<Variable Class="CollectionVariable">
+					<Id>1594231901088</Id>
+					<Name><![CDATA[StateHistory]]></Name>
+					<X>630</X><Y>1165</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" AccessType="public" StaticVariable="false">
+						<CollectionClass><![CDATA[ArrayList]]></CollectionClass>
+						<ElementClass><![CDATA[Main.statechart_state]]></ElementClass>
+						<ValueElementClass><![CDATA[String]]></ValueElementClass>
+					</Properties>
+
+				</Variable>
+				<Variable Class="CollectionVariable">
+					<Id>1597079424106</Id>
+					<Name><![CDATA[MostRecentRegimenHistory]]></Name>
+					<X>230</X><Y>1310</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" AccessType="public" StaticVariable="false">
+						<CollectionClass><![CDATA[ArrayList]]></CollectionClass>
+						<ElementClass><![CDATA[Integer]]></ElementClass>
+						<ValueElementClass><![CDATA[String]]></ValueElementClass>
+					</Properties>
+
+				</Variable>
+				<Variable Class="CollectionVariable">
+					<Id>1597080464317</Id>
+					<Name><![CDATA[NightmareDistressHistory]]></Name>
+					<X>260</X><Y>1450</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" AccessType="public" StaticVariable="false">
+						<CollectionClass><![CDATA[ArrayList]]></CollectionClass>
+						<ElementClass><![CDATA[Double]]></ElementClass>
+						<ValueElementClass><![CDATA[String]]></ValueElementClass>
+					</Properties>
+
+				</Variable>
+				<Variable Class="CollectionVariable">
+					<Id>1597080544217</Id>
+					<Name><![CDATA[NightmareEffectsHistory]]></Name>
+					<X>260</X><Y>1480</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" AccessType="public" StaticVariable="false">
+						<CollectionClass><![CDATA[ArrayList]]></CollectionClass>
+						<ElementClass><![CDATA[Double]]></ElementClass>
+						<ValueElementClass><![CDATA[String]]></ValueElementClass>
+					</Properties>
+
+				</Variable>
+				<Variable Class="CollectionVariable">
+					<Id>1597080557349</Id>
+					<Name><![CDATA[DASSAnxietyHistory]]></Name>
+					<X>260</X><Y>1500</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" AccessType="public" StaticVariable="false">
+						<CollectionClass><![CDATA[ArrayList]]></CollectionClass>
+						<ElementClass><![CDATA[Double]]></ElementClass>
+						<ValueElementClass><![CDATA[String]]></ValueElementClass>
+					</Properties>
+
+				</Variable>
 			</Variables>
 			<Dependences>
-				<Link SourceId="1591106657472" TargetId="1590316182063" Polarity="null">
+				<Link SourceId="1591106657472" Polarity="null">
 					<Height>-41.455</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>260</X><Y>100</Y></Direction>
 					<Id>1590354215249</Id>
-					<Name><![CDATA[<Fear> - <DandRFails>]]></Name>
+					<Name><![CDATA[<Fear> - ]]></Name>
 					<X>370</X><Y>380</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1568,12 +1370,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590274267533" TargetId="1590350936277" Polarity="null">
+				<Link SourceId="1590274267533" Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-290</Y></Direction>
 					<Id>1590354283541</Id>
-					<Name><![CDATA[FearExtinctionFailureThreshold - <FearExtinctionFails>]]></Name>
+					<Name><![CDATA[FearExtinctionFailureThreshold - ]]></Name>
 					<X>230</X><Y>740</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1598,12 +1400,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591051655412" TargetId="1590356917409" Polarity="null">
+				<Link SourceId="1591051655412" Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-30</Y></Direction>
 					<Id>1590357047313</Id>
-					<Name><![CDATA[MaxHoursSleepPerNight - <EndSleep>]]></Name>
+					<Name><![CDATA[MaxHoursSleepPerNight - ]]></Name>
 					<X>230</X><Y>570</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1613,12 +1415,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591097038621" TargetId="1590316182063" Polarity="null">
+				<Link SourceId="1591097038621" Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-500</Y></Direction>
 					<Id>1590357128194</Id>
-					<Name><![CDATA[AffectLoad - <DandRFails>]]></Name>
+					<Name><![CDATA[AffectLoad - ]]></Name>
 					<X>230</X><Y>980</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1628,12 +1430,11 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590446887199" TargetId="1590316119123" Polarity="null">
+				<Link Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-130</Y></Direction>
 					<Id>1590446970140</Id>
-					<Name><![CDATA[FearExtinctionCompletionThreshold - <FearExtinctionComplete>]]></Name>
 					<X>230</X><Y>760</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1658,12 +1459,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590347341808" TargetId="1590316182063" Polarity="null">
+				<Link SourceId="1590347341808" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>0</Y></Direction>
 					<Id>1590678398308</Id>
-					<Name><![CDATA[ImageValence - <DandRFails>]]></Name>
+					<Name><![CDATA[ImageValence - ]]></Name>
 					<X>230</X><Y>480</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1673,12 +1474,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591106657472" TargetId="1590350936277" Polarity="null">
+				<Link SourceId="1591106657472" Polarity="null">
 					<Height>-38.474</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>260</X><Y>70</Y></Direction>
 					<Id>1590678799016</Id>
-					<Name><![CDATA[<Fear> - <FearExtinctionFails>]]></Name>
+					<Name><![CDATA[<Fear> - ]]></Name>
 					<X>370</X><Y>380</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1733,12 +1534,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591106657472" TargetId="1590356917409" Polarity="null">
+				<Link SourceId="1591106657472" Polarity="null">
 					<Height>-37.684</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>260</X><Y>160</Y></Direction>
 					<Id>1590858783592</Id>
-					<Name><![CDATA[<Fear> - <EndSleep>]]></Name>
+					<Name><![CDATA[<Fear> - ]]></Name>
 					<X>370</X><Y>380</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1763,93 +1564,18 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590272858168" TargetId="1590273070750" Polarity="null">
-					<Height>-9.004</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>-200</X><Y>0</Y></Direction>
-					<Id>1590862040914</Id>
-					<Name><![CDATA[FearExtinctionComplete - FearExtinctionPartial]]></Name>
-					<X>1390</X><Y>460</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-10496</Color>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1590349895427" TargetId="1590273070750" Polarity="null">
-					<Height>-32.0</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>-100</X><Y>-250</Y></Direction>
-					<Id>1590862051753</Id>
-					<Name><![CDATA[FearExtinctionFails - FearExtinctionPartial]]></Name>
-					<X>1700</X><Y>760</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-10496</Color>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1590355744865" TargetId="1590355791892" Polarity="null">
-					<Height>0.0</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>300</X><Y>-50</Y></Direction>
-					<Id>1590862124073</Id>
-					<Name><![CDATA[EndSleep - RestartDreamingFromAwake]]></Name>
-					<X>1200</X><Y>810</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-16711681</Color>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1590273663214" TargetId="1591006489550" Polarity="null">
-					<Height>-19.139</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>200</X><Y>-300</Y></Direction>
-					<Id>1591006988684</Id>
-					<Name><![CDATA[DandRFails - DreamingNoFearExtinction]]></Name>
-					<X>1300</X><Y>660</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-16711936</Color>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1591097038621" TargetId="1590316084943" Polarity="null">
+				<Link SourceId="1591097038621" Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-590</Y></Direction>
 					<Id>1591007135045</Id>
-					<Name><![CDATA[AffectLoad - <DandRSucceeds>]]></Name>
+					<Name><![CDATA[AffectLoad - ]]></Name>
 					<X>230</X><Y>980</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
 					<ShowLabel>false</ShowLabel>
 					<Color/>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1590272730536" TargetId="1591006489550" Polarity="null">
-					<Height>19.017</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>0</X><Y>-200</Y></Direction>
-					<Id>1591007191480</Id>
-					<Name><![CDATA[DandRSucceeds - DreamingNoFearExtinction]]></Name>
-					<X>1500</X><Y>560</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-16711936</Color>
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
@@ -1883,12 +1609,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591012739489" TargetId="1590316084943" Polarity="null">
+				<Link SourceId="1591012739489" Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-310</Y></Direction>
 					<Id>1591033572558</Id>
-					<Name><![CDATA[FearExtinctionAttemptThreshold - <DandRSucceeds>]]></Name>
+					<Name><![CDATA[FearExtinctionAttemptThreshold - ]]></Name>
 					<X>230</X><Y>700</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1898,12 +1624,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591012739489" TargetId="1590316182063" Polarity="null">
+				<Link SourceId="1591012739489" Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-220</Y></Direction>
 					<Id>1591033661722</Id>
-					<Name><![CDATA[FearExtinctionAttemptThreshold - <DandRFails>]]></Name>
+					<Name><![CDATA[FearExtinctionAttemptThreshold - ]]></Name>
 					<X>230</X><Y>700</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1913,12 +1639,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590347341808" TargetId="1590316084943" Polarity="null">
+				<Link SourceId="1590347341808" Polarity="null">
 					<Height>-23.149</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-90</Y></Direction>
 					<Id>1591094204311</Id>
-					<Name><![CDATA[ImageValence - <DandRSucceeds>]]></Name>
+					<Name><![CDATA[ImageValence - ]]></Name>
 					<X>230</X><Y>480</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1928,12 +1654,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591106657472" TargetId="1590316084943" Polarity="null">
+				<Link SourceId="1591106657472" Polarity="null">
 					<Height>-41.035</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>260</X><Y>10</Y></Direction>
 					<Id>1591094208966</Id>
-					<Name><![CDATA[<Fear> - <DandRSucceeds>]]></Name>
+					<Name><![CDATA[<Fear> - ]]></Name>
 					<X>370</X><Y>380</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1943,12 +1669,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591034183128" TargetId="1590316084943" Polarity="null">
+				<Link SourceId="1591034183128" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-330</Y></Direction>
 					<Id>1591094218214</Id>
-					<Name><![CDATA[DandRFailureThreshold - <DandRSucceeds>]]></Name>
+					<Name><![CDATA[DandRFailureThreshold - ]]></Name>
 					<X>230</X><Y>720</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1958,12 +1684,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591034183128" TargetId="1590316182063" Polarity="null">
+				<Link SourceId="1591034183128" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-240</Y></Direction>
 					<Id>1591094634103</Id>
-					<Name><![CDATA[DandRFailureThreshold - <DandRFails>]]></Name>
+					<Name><![CDATA[DandRFailureThreshold - ]]></Name>
 					<X>230</X><Y>720</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1973,12 +1699,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591097038621" TargetId="1590316119123" Polarity="null">
+				<Link SourceId="1591097038621" Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-350</Y></Direction>
 					<Id>1591094873137</Id>
-					<Name><![CDATA[AffectLoad - <FearExtinctionComplete>]]></Name>
+					<Name><![CDATA[AffectLoad - ]]></Name>
 					<X>230</X><Y>980</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -1988,12 +1714,11 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590446887199" TargetId="1590350936277" Polarity="null">
+				<Link Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-310</Y></Direction>
 					<Id>1591095266089</Id>
-					<Name><![CDATA[FearExtinctionCompletionThreshold - <FearExtinctionFails>]]></Name>
 					<X>230</X><Y>760</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2003,12 +1728,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591097038621" TargetId="1590350936277" Polarity="null">
+				<Link SourceId="1591097038621" Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-530</Y></Direction>
 					<Id>1591095278658</Id>
-					<Name><![CDATA[AffectLoad - <FearExtinctionFails>]]></Name>
+					<Name><![CDATA[AffectLoad - ]]></Name>
 					<X>230</X><Y>980</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2018,12 +1743,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591095540425" TargetId="1590356917409" Polarity="null">
+				<Link SourceId="1591095540425" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-460</Y></Direction>
 					<Id>1591098371012</Id>
-					<Name><![CDATA[HoursSleepTonight - <EndSleep>]]></Name>
+					<Name><![CDATA[HoursSleepTonight - ]]></Name>
 					<X>230</X><Y>1000</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2033,12 +1758,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591098449521" TargetId="1590356917409" Polarity="null">
+				<Link SourceId="1591098449521" Polarity="null">
 					<Height>0.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-240</Y></Direction>
 					<Id>1591098482233</Id>
-					<Name><![CDATA[PostNightmareSleepThreshold - <EndSleep>]]></Name>
+					<Name><![CDATA[PostNightmareSleepThreshold - ]]></Name>
 					<X>230</X><Y>780</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2048,57 +1773,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590273064457" TargetId="1591100309149" Polarity="null">
-					<Height>31.953</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>-110</X><Y>90</Y></Direction>
-					<Id>1591100320468</Id>
-					<Name><![CDATA[WorkingMemoryImages - Perseveration]]></Name>
-					<X>1100</X><Y>660</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-14774017</Color>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1591100309149" TargetId="1591103848796" Polarity="null">
-					<Height>93.045</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>0</X><Y>-200</Y></Direction>
-					<Id>1591103872233</Id>
-					<Name><![CDATA[Perseveration - SleepAvoidance]]></Name>
-					<X>990</X><Y>750</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-14774017</Color>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1591103848796" TargetId="1590273332463" Polarity="null">
-					<Height>25.42</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>210</X><Y>60</Y></Direction>
-					<Id>1591103880977</Id>
-					<Name><![CDATA[SleepAvoidance - StartSleep]]></Name>
-					<X>990</X><Y>550</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-14774017</Color>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1591106187413" TargetId="1590316466437" Polarity="null">
+				<Link SourceId="1591106187413" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-590</Y></Direction>
 					<Id>1591107527933</Id>
-					<Name><![CDATA[HourOfDay - <StartSleep>]]></Name>
+					<Name><![CDATA[HourOfDay - ]]></Name>
 					<X>230</X><Y>1160</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2108,12 +1788,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591106138749" TargetId="1590316466437" Polarity="null">
+				<Link SourceId="1591106138749" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>-40</Y></Direction>
 					<Id>1591107548938</Id>
-					<Name><![CDATA[NormalSleepHour - <StartSleep>]]></Name>
+					<Name><![CDATA[NormalSleepHour - ]]></Name>
 					<X>230</X><Y>610</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2123,12 +1803,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591187080286" TargetId="1590316466437" Polarity="null">
+				<Link SourceId="1591187080286" Polarity="null">
 					<Height>-32.67</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>260</X><Y>170</Y></Direction>
 					<Id>1591107598563</Id>
-					<Name><![CDATA[<SleepAvoidance> - <StartSleep>]]></Name>
+					<Name><![CDATA[<SleepAvoidance> - ]]></Name>
 					<X>370</X><Y>400</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2168,21 +1848,6 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591109972842" TargetId="1590273332463" Polarity="null">
-					<Height>20.0</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>210</X><Y>160</Y></Direction>
-					<Id>1591110042020</Id>
-					<Name><![CDATA[SleepPressure - StartSleep]]></Name>
-					<X>990</X><Y>450</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-14774017</Color>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
 				<Link SourceId="1590272662305" TargetId="1591107586905" Polarity="null">
 					<Height>-28.771</Height>
 					<PolarityPosition>0.95</PolarityPosition>
@@ -2198,12 +1863,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590272662305" TargetId="1591111183884" Polarity="null">
+				<Link SourceId="1590272662305" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>440</Y></Direction>
 					<Id>1591111197649</Id>
-					<Name><![CDATA[AffectDistressTendency - <Perseveration>]]></Name>
+					<Name><![CDATA[AffectDistressTendency - ]]></Name>
 					<X>230</X><Y>370</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2213,12 +1878,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590274024200" TargetId="1591111183884" Polarity="null">
+				<Link SourceId="1590274024200" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>420</Y></Direction>
 					<Id>1591177728279</Id>
-					<Name><![CDATA[TraumaHistory - <Perseveration>]]></Name>
+					<Name><![CDATA[TraumaHistory - ]]></Name>
 					<X>230</X><Y>390</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2228,12 +1893,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590347366159" TargetId="1591111183884" Polarity="null">
+				<Link SourceId="1590347366159" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>310</Y></Direction>
 					<Id>1591177743342</Id>
-					<Name><![CDATA[ImageDominance - <Perseveration>]]></Name>
+					<Name><![CDATA[ImageDominance - ]]></Name>
 					<X>230</X><Y>500</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2243,12 +1908,12 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1590347364670" TargetId="1591111183884" Polarity="null">
+				<Link SourceId="1590347364670" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
 					<Direction><X>400</X><Y>290</Y></Direction>
 					<Id>1591177747894</Id>
-					<Name><![CDATA[ImageArousal - <Perseveration>]]></Name>
+					<Name><![CDATA[ImageArousal - ]]></Name>
 					<X>230</X><Y>520</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
@@ -2280,36 +1945,6 @@
 					<Id>1591183505220</Id>
 					<Name><![CDATA[TraumaHistory - <SleepAvoidance>]]></Name>
 					<X>230</X><Y>390</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color/>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1591046767327" TargetId="1591110021172" Polarity="null">
-					<Height>20.0</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>400</X><Y>230</Y></Direction>
-					<Id>1591184995749</Id>
-					<Name><![CDATA[MaxREMCyclesPerNight - <SleepPressure>]]></Name>
-					<X>230</X><Y>550</Y>
-					<Label><X>40</X><Y>-50</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color/>
-					<LineWidth>1</LineWidth>
-					<Delay>false</Delay>
-				</Link>
-				<Link SourceId="1591051655412" TargetId="1591110021172" Polarity="null">
-					<Height>20.0</Height>
-					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>400</X><Y>210</Y></Direction>
-					<Id>1591185042854</Id>
-					<Name><![CDATA[MaxHoursSleepPerNight - <SleepPressure>]]></Name>
-					<X>230</X><Y>570</Y>
 					<Label><X>40</X><Y>-50</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -2798,13 +2433,13 @@
 					<LineWidth>1</LineWidth>
 					<Delay>false</Delay>
 				</Link>
-				<Link SourceId="1591111183884" TargetId="1590353813015" Polarity="null">
+				<Link SourceId="1594142480485" TargetId="1591107586905" Polarity="null">
 					<Height>20.0</Height>
 					<PolarityPosition>0.95</PolarityPosition>
-					<Direction><X>0</X><Y>-120</Y></Direction>
-					<Id>1593030144920</Id>
-					<Name><![CDATA[<Perseveration> - NightmareEffects]]></Name>
-					<X>630</X><Y>810</Y>
+					<Direction><X>20</X><Y>-60</Y></Direction>
+					<Id>1594143283324</Id>
+					<Name><![CDATA[Perseveration - <SleepAvoidance>]]></Name>
+					<X>610</X><Y>810</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -2815,71 +2450,11 @@
 				</Link>
 			</Dependences>
 			<CausalLoops>
-				<CausalLoop Clockwise="false">
-					<Type><![CDATA[B]]></Type>
-					<Id>1590273857928</Id>
-					<Name><![CDATA[loop]]></Name>
-					<X>1380</X><Y>640</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-4565549</Color>
-					<Text><![CDATA[TraumNM Loop (PC)]]></Text>
-				</CausalLoop>
-				<CausalLoop Clockwise="false">
-					<Type><![CDATA[B]]></Type>
-					<Id>1590273873282</Id>
-					<Name><![CDATA[loop1]]></Name>
-					<X>1500</X><Y>500</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-10496</Color>
-					<Text><![CDATA[FearExtinction Loop (YG)]]></Text>
-				</CausalLoop>
-				<CausalLoop Clockwise="true">
-					<Type><![CDATA[B]]></Type>
-					<Id>1590355338605</Id>
-					<Name><![CDATA[loop2]]></Name>
-					<X>1550</X><Y>600</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color>-65536</Color>
-					<Text><![CDATA[NontraumNM Loop (YRC)]]></Text>
-				</CausalLoop>
-				<CausalLoop Clockwise="true">
-					<Type><![CDATA[B]]></Type>
-					<Id>1590356553496</Id>
-					<Name><![CDATA[loop3]]></Name>
-					<X>1220</X><Y>640</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color/>
-					<Text><![CDATA[TraumWake Loop (PB)]]></Text>
-				</CausalLoop>
-				<CausalLoop Clockwise="true">
-					<Type><![CDATA[B]]></Type>
-					<Id>1590356571654</Id>
-					<Name><![CDATA[loop4]]></Name>
-					<X>1480</X><Y>700</Y>
-					<Label><X>10</X><Y>0</Y></Label>
-					<PublicFlag>false</PublicFlag>
-					<PresentationFlag>true</PresentationFlag>
-					<ShowLabel>false</ShowLabel>
-					<Color/>
-					<Text><![CDATA[NontraumWake Loop (YRB)]]></Text>
-				</CausalLoop>
 				<CausalLoop Clockwise="true">
 					<Type><![CDATA[R]]></Type>
 					<Id>1591103913505</Id>
 					<Name><![CDATA[loop5]]></Name>
-					<X>1020</X><Y>610</Y>
+					<X>570</X><Y>2060</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -2888,11 +2463,588 @@
 					<Text><![CDATA[SleepAvoidance Loops (BPB, BYRB)]]></Text>
 				</CausalLoop>
 			</CausalLoops>
+			<StatechartElements>
+				<StatechartElement Class="State" ParentState="ROOT_NODE">
+					<Id>1594141370916</Id>
+					<Name><![CDATA[EventMemoryImagesInSleep]]></Name>
+					<X>1240</X><Y>590</Y>
+					<Label><X>15</X><Y>20</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties Width="290" Height="40">
+						<EntryAction><![CDATA[StateHistory.add(this.EventMemoryImagesInSleep)]]></EntryAction>
+						<FillColor>-4144960</FillColor>
+					</Properties>
+				</StatechartElement>
+				<StatechartElement Class="State" ParentState="ROOT_NODE">
+					<Id>1594141438585</Id>
+					<Name><![CDATA[RecontextualizedImages]]></Name>
+					<X>2000</X><Y>590</Y>
+					<Label><X>15</X><Y>20</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties Width="230" Height="40">
+						<EntryAction><![CDATA[StateHistory.add(RecontextualizedImages);]]></EntryAction>
+						<FillColor>-10496</FillColor>
+					</Properties>
+				</StatechartElement>
+				<StatechartElement Class="State" ParentState="ROOT_NODE">
+					<Id>1594141459075</Id>
+					<Name><![CDATA[DepotentiatedImages]]></Name>
+					<X>1740</X><Y>810</Y>
+					<Label><X>25</X><Y>25</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties Width="230" Height="50">
+						<EntryAction><![CDATA[StateHistory.add(this.DepotentiatedImages)]]></EntryAction>
+						<FillColor>-16711936</FillColor>
+					</Properties>
+				</StatechartElement>
+				<StatechartElement Class="State" ParentState="ROOT_NODE">
+					<Id>1594141471821</Id>
+					<Name><![CDATA[AwakeImageAwareness]]></Name>
+					<X>1230</X><Y>940</Y>
+					<Label><X>20</X><Y>15</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties Width="230" Height="40">
+						<EntryAction><![CDATA[StateHistory.add(this.AwakeImageAwareness)]]></EntryAction>
+						<FillColor>-360334</FillColor>
+					</Properties>
+				</StatechartElement>
+				<StatechartElement Class="State" ParentState="ROOT_NODE">
+					<Id>1594141494642</Id>
+					<Name><![CDATA[WorkingMemoryImages]]></Name>
+					<X>890</X><Y>790</Y>
+					<Label><X>30</X><Y>30</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties Width="260" Height="60">
+						<EntryAction><![CDATA[Perseveration = calculatePerseveration();
+StateHistory.add(this.WorkingMemoryImages);]]></EntryAction>
+						<FillColor>-16711681</FillColor>
+					</Properties>
+				</StatechartElement>
+				<StatechartElement Class="Branch" ParentState="ROOT_NODE">
+					<Id>1594141728877</Id>
+					<Name><![CDATA[branch1]]></Name>
+					<X>1770</X><Y>620</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Properties>	
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Branch" ParentState="ROOT_NODE">
+					<Id>1594141991825</Id>
+					<Name><![CDATA[branch2]]></Name>
+					<X>2070</X><Y>960</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Properties>	
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Branch" ParentState="ROOT_NODE">
+					<Id>1594142293159</Id>
+					<Name><![CDATA[branch4]]></Name>
+					<X>1290</X><Y>840</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Properties>	
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Branch" ParentState="ROOT_NODE">
+					<Id>1594142384163</Id>
+					<Name><![CDATA[branch5]]></Name>
+					<X>1190</X><Y>710</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Properties>	
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594141578560</Id>
+					<Name><![CDATA[transition]]></Name>
+					<X>1530</X><Y>620</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>228</X><Y>0</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594141370916" Target="1594141728877" Trigger="timeout">
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[TimeInState]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[true]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>true</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594141628722</Id>
+					<Name><![CDATA[Depotentiation]]></Name>
+					<X>1770</X><Y>630</Y>
+					<Label><X>5</X><Y>95</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>0</X><Y>180</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594141728877" Target="1594141459075" Trigger="timeout">
+						<Action><![CDATA[OnTransitionFromSleepingState();]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[true]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>true</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594141772824</Id>
+					<Name><![CDATA[DandRFails]]></Name>
+					<X>1758</X><Y>620</Y>
+					<Label><X>-188</X><Y>195</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>-352</X><Y>320</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594141728877" Target="1594141471821" Trigger="timeout">
+						<Action><![CDATA[OnTraumaticNM();]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[(ImageValence < 0) && (AffectLoad > FearExtinctionAttemptThreshold) && (Fear >= DandRFailureThreshold)]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>false</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594141851922</Id>
+					<Name><![CDATA[transition1]]></Name>
+					<X>1782</X><Y>620</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>218</X><Y>0</Y></Point>
+					</Points>
+					<IconOffset>30.0</IconOffset>
+					<Properties Source="1594141728877" Target="1594141438585" Trigger="timeout">
+						<Action><![CDATA[OnTransitionFromSleepingState();]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[(ImageValence < 0) && (AffectLoad > FearExtinctionAttemptThreshold) && (Fear < DandRFailureThreshold)]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>false</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594141961516</Id>
+					<Name><![CDATA[transition3]]></Name>
+					<X>2070</X><Y>630</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>0</X><Y>320</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594141438585" Target="1594141991825" Trigger="timeout">
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[TimeInState]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[true]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>true</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594142106394</Id>
+					<Name><![CDATA[FearExtinctionFails]]></Name>
+					<Description><![CDATA[Transition will increment HourOfRun and HoursSleep, so we need to add 1 here.]]></Description>
+					<X>2058</X><Y>960</Y>
+					<Label><X>-373</X><Y>25</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>-598</X><Y>0</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594141991825" Target="1594141471821" Trigger="timeout">
+						<Action><![CDATA[OnNonTraumaticNM();]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[(Fear > FearExtinctionFailureThreshold)]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>false</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594142156373</Id>
+					<Name><![CDATA[FearExtinctionPartial]]></Name>
+					<X>2082</X><Y>960</Y>
+					<Label><X>-157</X><Y>-440</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>188</X><Y>-110</Y></Point>
+						<Point><X>188</X><Y>-420</Y></Point>
+						<Point><X>-582</X><Y>-420</Y></Point>
+						<Point><X>-582</X><Y>-370</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594141991825" Target="1594141370916" Trigger="timeout">
+						<Action><![CDATA[OnFEPartial();]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[true]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>true</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594142288700</Id>
+					<Name><![CDATA[transition4]]></Name>
+					<X>1290</X><Y>940</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>0</X><Y>-90</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594141471821" Target="1594142293159" Trigger="timeout">
+						<Action><![CDATA[OnTransitionOutOfState();]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[TimeInState]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[true]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>true</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594142323311</Id>
+					<Name><![CDATA[EndSleep]]></Name>
+					<X>1278</X><Y>840</Y>
+					<Label><X>-108</X><Y>15</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>-128</X><Y>0</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594142293159" Target="1594141494642" Trigger="timeout">
+						<Action><![CDATA[traceln("Hours sleep tonight: " + HoursSleepTonight);
+traceln("Max hours sleep: " + MaxHoursSleepPerNight);
+traceln("Fear: " + Fear);
+traceln("POstNight " + PostNightmareSleepThreshold);
+
+EndSleepForNight();]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[(HourOfRun - RunHourMostRecentlyAttemptedSleep >= MaxHoursSleepPerNight)
+ || (Fear >= PostNightmareSleepThreshold)]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>false</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594142360703</Id>
+					<Name><![CDATA[RestartDreamingFromAwake]]></Name>
+					<X>1290</X><Y>830</Y>
+					<Label><X>10</X><Y>-95</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>0</X><Y>-200</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594142293159" Target="1594141370916" Trigger="timeout">
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[true]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>true</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594142545254</Id>
+					<Name><![CDATA[transition6]]></Name>
+					<X>1130</X><Y>790</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>60</X><Y>-70</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594141494642" Target="1594142384163" Trigger="timeout">
+						<Action><![CDATA[OnTransitionOutOfState();]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[TimeInState]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[true]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>true</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594142573857</Id>
+					<Name><![CDATA[StartSleep]]></Name>
+					<X>1190</X><Y>700</Y>
+					<Label><X>-55</X><Y>-45</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>60</X><Y>-70</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594142384163" Target="1594141370916" Trigger="timeout">
+						<Action><![CDATA[Perseveration = 0;
+RunHourMostRecentlyAttemptedSleep = HourOfRun;]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[(HourOfDay == NormalSleepHour) && (SleepAvoidance < SleepPressure)]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>false</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594142614731</Id>
+					<Name><![CDATA[transition7]]></Name>
+					<X>1190</X><Y>720</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>-60</X><Y>70</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594142384163" Target="1594141494642" Trigger="timeout">
+						<Action><![CDATA[if (HourOfDay == NormalSleepHour) {
+	EndSleepForNight();
+}]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[true]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>true</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="EntryPoint" ParentState="ROOT_NODE">
+					<Id>1594143225952</Id>
+					<Name><![CDATA[statechart]]></Name>
+					<X>1290</X><Y>550</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>0</X><Y>40</Y></Point>
+					</Points>
+					<Properties Target="1594141370916">
+						<Action><![CDATA[RunHourMostRecentlyAttemptedSleep = HourOfRun;]]></Action>
+					</Properties>	
+				</StatechartElement>
+				<StatechartElement Class="Transition" ParentState="ROOT_NODE">
+					<Id>1594323716188</Id>
+					<Name><![CDATA[transition2]]></Name>
+					<Description><![CDATA[Transition will increment HourOfRun and HoursSleep, so we need to add 1 here.]]></Description>
+					<X>2070</X><Y>970</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<Points>
+						<Point><X>0</X><Y>0</Y></Point>
+						<Point><X>0</X><Y>90</Y></Point>
+						<Point><X>-1050</X><Y>90</Y></Point>
+						<Point><X>-1050</X><Y>-120</Y></Point>
+					</Points>
+					<IconOffset>20.0</IconOffset>
+					<Properties Source="1594141991825" Target="1594141494642" Trigger="timeout">
+						<Action><![CDATA[OnFEPartial();
+EndSleepForNight();]]></Action>
+						<Timeout Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="TimeUnits"><![CDATA[HOUR]]></Unit>
+						</Timeout>
+						<Condition><![CDATA[(HourOfRun - RunHourMostRecentlyAttemptedSleep + 1 >= MaxHoursSleepPerNight)
+&& (Fear <= FearExtinctionFailureThreshold)]]></Condition>
+						<Rate Class="CodeUnitValue">
+							<Code><![CDATA[1]]></Code>
+							<Unit Class="RateUnits"><![CDATA[PER_HOUR]]></Unit>
+						</Rate>
+						<MessageType><![CDATA[Object]]></MessageType>
+						<DefaultTransition>false</DefaultTransition>
+						<FilterType><![CDATA[unconditionally]]></FilterType>
+						<EqualsExpression><![CDATA["text"]]></EqualsExpression>
+						<SatisfiesExpression><![CDATA[true]]></SatisfiesExpression>
+					</Properties>	
+				</StatechartElement>
+			</StatechartElements>
 			<Events>
 				<Event>
 					<Id>1590445884081</Id>
 					<Name><![CDATA[HourlyEvent]]></Name>
-					<X>630</X><Y>1180</Y>
+					<X>615</X><Y>1695</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>false</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3012,8 +3164,8 @@ Treatment parameters are:
 //Define sleep variables
 //SleepTime (indicates whether person is sleeping or trying to sleep)
 //SleepEnd (indicates that person just woke (used for updating some variables and collections
-boolean SleepTime = false;	//default
-if (WorkingMemoryImages == 0) {	//catch stock indicating daytime activity
+/*boolean SleepTime = false;	//default
+if (!this.inState(Main.sc_WorkingMemoryImages)) {	//catch stock indicating daytime activity
 	SleepTime = true;	
 }
 boolean SleepEnd = false;
@@ -3022,6 +3174,7 @@ if (EndSleep == 0) {				//catch flow indicating end of sleep
 }
 
 //Update tracking variables and collections with initial conditions - before any treatments are applied
+
 if (HourOfRun == 0) {
 	HoursSleepTonight = 0;
 	HoursSleepHistory.add(0.0);
@@ -3089,6 +3242,400 @@ if (HourOfDay >= 24) {
 /* ************************************************************************************************************ */]]></Action>
 				</Event>
 			</Events>
+			<Functions>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594227255755</Id>
+					<Name><![CDATA[OnTransitionOutOfState]]></Name>
+					<X>630</X><Y>1220</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[HourOfRun ++;
+HourOfDay = (HourOfDay + 1) % 24;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594227563609</Id>
+					<Name><![CDATA[OnTransitionFromSleepingState]]></Name>
+					<X>630</X><Y>1240</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[HoursSleepTonight++;
+OnTransitionOutOfState();]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594227791828</Id>
+					<Name><![CDATA[OnTraumaticNM]]></Name>
+					<X>630</X><Y>1260</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[TraumNMTonight += 1;
+AffectLoad += TNMAffectLoadIncrement;
+OnTransitionFromSleepingState();
+MostRecentRegimen = 3;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594227946002</Id>
+					<Name><![CDATA[OnNonTraumaticNM]]></Name>
+					<X>630</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[NonTraumNMTonight += 1;
+AffectLoad += NTNMAffectLoadIncrement;
+traceln("NonTraumNM! " + NonTraumNMTonight);
+OnTransitionFromSleepingState();
+MostRecentRegimen = 2;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594228222306</Id>
+					<Name><![CDATA[OnFEPartial]]></Name>
+					<X>630</X><Y>1300</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[AffectLoad -= FEAffectLoadDecrement;
+REMPeriodsTonight += 1;
+OnTransitionFromSleepingState();
+MostRecentRegimen = 1;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594228744495</Id>
+					<Name><![CDATA[EndSleepForNight]]></Name>
+					<X>630</X><Y>1320</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[HoursSleepHistory.add(HoursSleepTonight);
+REMPeriodsHistory.add(REMPeriodsTonight);
+
+double sleepDeficitTonight = max(0.0, MaxHoursSleepPerNight - HoursSleepTonight) / MaxHoursSleepPerNight;
+SleepDeficitHistory.add(sleepDeficitTonight);
+
+double REMDeficitTonight = max(0.0, MaxREMCyclesPerNight - REMPeriodsTonight) / MaxREMCyclesPerNight;
+REMDeficitHistory.add(REMDeficitTonight);
+
+NonTraumNMHistory.add(NonTraumNMTonight);
+
+TraumNMHistory.add(NonTraumNMTonight);
+
+double NMIntensityTonight = min(1.0,
+	(NonTraumNMTonight + 2*TraumNMTonight) / MaxREMCyclesPerNight);
+NMIntensityHistory.add(NMIntensityTonight);
+
+AffectLoadHistory.add(AffectLoad);
+MostRecentRegimenHistory.add(MostRecentRegimen);
+NightmareDistressHistory.add(NightmareDistress);
+NightmareEffectsHistory.add(NightmareEffects);
+DASSAnxietyHistory.add(DASSAnxiety);
+
+SleepDeficitLastWeek = SleepDeficitHistory
+	.subList(max(0, SleepDeficitHistory.size() - 7), max(7, SleepDeficitHistory.size()))
+	.stream().mapToDouble(Double::doubleValue).average().getAsDouble();
+REMDeficitLastWeek = REMDeficitHistory
+	.subList(max(0, REMDeficitHistory.size() - 7), max(7, REMDeficitHistory.size()))
+	.stream().mapToDouble(Double::doubleValue).average().getAsDouble();
+NMIntensityLastWeek = NMIntensityHistory
+	.subList(max(0, NMIntensityHistory.size() - 7), max(7, NMIntensityHistory.size()))
+	.stream().mapToDouble(Double::doubleValue).average().getAsDouble();
+
+REMPeriodsTonight = 0;
+HoursSleepTonight = 0;
+NonTraumNMTonight = 0;
+TraumNMTonight = 0;
+
+// Ignore treatment for now.
+//HoursSinceLastTreatment = 0;
+//TreatmentHistory.add(0.0);]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594231671566</Id>
+					<Name><![CDATA[Init]]></Name>
+					<X>630</X><Y>1340</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[AffectLoad = InitialAffectLoad;
+HourOfDay = NormalSleepHour;
+
+for (int i = 0; i < 7; i++) {
+	HoursSleepHistory.add(MaxHoursSleepPerNight);
+	REMPeriodsHistory.add(MaxREMCyclesPerNight);
+	SleepDeficitHistory.add(0.0);
+	REMDeficitHistory.add(0.0);
+	NonTraumNMHistory.add(0.0);
+	TraumNMHistory.add(0.0);
+	NMIntensityHistory.add(0.0);
+}
+
+REMPeriodsTonight = 0;
+HoursSleepTonight = 0;
+NonTraumNMTonight = 0;
+TraumNMTonight = 0;
+
+// Not sure about these init values
+ControlCapacityHistory.add(0.0);
+ControlCapacity = 0;
+MostRecentRegimenHistory.add(0);]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594235599543</Id>
+					<Name><![CDATA[DisplayTestResult]]></Name>
+					<X>630</X><Y>1380</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[result]]></Name>
+						<Type><![CDATA[TestResult]]></Type>
+					</Parameter>
+					<Body><![CDATA[if (result.state == TestResult.TestResultState.PASS) {
+	test_color.setFillColor(new Color(0, 255, 0, 255));
+	testOutput.setText("TEST PASSES");	
+} else if (result.state == TestResult.TestResultState.FAIL) {
+	test_color.setFillColor(new Color(255, 0, 0, 255));
+	testOutput.setText(result.errorMessage);
+}]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594321094149</Id>
+					<Name><![CDATA[CheckInputs]]></Name>
+					<X>630</X><Y>1410</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[String inputValidationMsg = "";
+
+if (DandRFailureThreshold <= FearExtinctionFailureThreshold) {
+	inputValidationMsg += "WARNING: DandRFailureThreshold <= FearExtinctionFailureThreshold";
+}
+
+if (inputValidationMsg.equals("")) {
+	text_inputValidation.setText("Input Validation: " + inputValidationMsg);
+} else {
+	text_inputValidation.setText("Input Validation: Success");
+}]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594394206873</Id>
+					<Name><![CDATA[GetOutput]]></Name>
+					<X>630</X><Y>1440</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[StringBuilder sb = new StringBuilder();
+
+sb.append(ExperimentId);
+sb.append(',');
+sb.append(AffectDistressTendency);
+sb.append(',');
+sb.append(TraumaHistory);
+sb.append(',');
+sb.append(InitialAffectLoad);
+sb.append(',');
+sb.append(Lucidity);
+sb.append(',');
+sb.append(ImageStabilizationCapacity);
+sb.append(',');
+sb.append(ImageValence);
+sb.append(',');
+sb.append(ImageDominance);
+sb.append(',');
+sb.append(ImageArousal);
+sb.append(',');
+sb.append(MaxREMCyclesPerNight);
+sb.append(',');
+sb.append(MaxHoursSleepPerNight);
+sb.append(',');
+sb.append(IdealHoursSleepPerNight);
+sb.append(',');
+sb.append(NormalSleepHour);
+sb.append(',');
+sb.append(NTNMAffectLoadIncrement);
+sb.append(',');
+sb.append(TNMAffectLoadIncrement);
+sb.append(',');
+sb.append(FEAffectLoadDecrement);
+sb.append(',');
+sb.append(FearExtinctionAttemptThreshold);
+sb.append(',');
+sb.append(DandRFailureThreshold);
+sb.append(',');
+sb.append(FearExtinctionFailureThreshold);
+sb.append(',');
+sb.append(PostNightmareSleepThreshold);
+sb.append(',');
+sb.append(TreatmentDegreeOfControl);
+sb.append(',');
+sb.append(TreatmentImagesSimilarToNM);
+sb.append(',');
+sb.append(AdrenalineAntagonists);
+sb.append(',');
+sb.append(TreatmentFrequency);
+sb.append(',');
+sb.append(TreatmentType);
+sb.append(',');
+sb.append(NightmareDistress);
+sb.append(',');
+sb.append(NightmareEffects);
+sb.append(',');
+sb.append(DASSAnxiety);
+sb.append(',');
+sb.append(MostRecentRegimen);
+
+return sb.toString();]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594394650293</Id>
+					<Name><![CDATA[GetHeaders]]></Name>
+					<X>630</X><Y>1470</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[StringBuilder sb = new StringBuilder();
+
+sb.append("AffectDistressTendency");
+sb.append(',');
+sb.append("TraumaHistory");
+sb.append(',');
+sb.append("InitialAffectLoad");
+sb.append(',');
+sb.append("Lucidity");
+sb.append(',');
+sb.append("ImageStabilizationCapacity");
+sb.append(',');
+sb.append("ImageValence");
+sb.append(',');
+sb.append("ImageDominance");
+sb.append(',');
+sb.append("ImageArousal");
+sb.append(',');
+sb.append("MaxREMCyclesPerNight");
+sb.append(',');
+sb.append("MaxHoursSleepPerNight");
+sb.append(',');
+sb.append("IdealHoursSleepPerNight");
+sb.append(',');
+sb.append("NormalSleepHour");
+sb.append(',');
+sb.append("NTNMAffectLoadIncrement");
+sb.append(',');
+sb.append("TNMAffectLoadIncrement");
+sb.append(',');
+sb.append("FEAffectLoadDecrement");
+sb.append(',');
+sb.append("FearExtinctionAttemptThreshold");
+sb.append(',');
+sb.append("DandRFailureThreshold");
+sb.append(',');
+sb.append("FearExtinctionFailureThreshold");
+sb.append(',');
+sb.append("PostNightmareSleepThreshold");
+sb.append(',');
+sb.append("TreatmentDegreeOfControl");
+sb.append(',');
+sb.append("TreatmentImagesSimilarToNM");
+sb.append(',');
+sb.append("AdrenalineAntagonists");
+sb.append(',');
+sb.append("TreatmentFrequency");
+sb.append(',');
+sb.append("TreatmentType");
+sb.append(',');
+sb.append("NightmareDistress");
+sb.append(',');
+sb.append("NightmareEffects");
+sb.append(',');
+sb.append("DASSAnxiety");
+
+return sb.toString();]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594413414352</Id>
+					<Name><![CDATA[calculatePerseveration]]></Name>
+					<X>630</X><Y>1490</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[return ((ImageDominance * ImageArousal) + TraumaHistory)/2 * AffectDistressTendency;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1597080259596</Id>
+					<Name><![CDATA[GetDailyOutput]]></Name>
+					<X>585</X><Y>1532</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[StringBuilder sb = new StringBuilder();
+
+for (int i = 0; i < AffectLoadHistory.size(); i++) {
+
+	sb.append(ExperimentId);
+	sb.append(',');
+	sb.append(i);
+	sb.append(',');
+	sb.append(NonTraumNMHistory.get(i + 7));
+	sb.append(',');
+	sb.append(TraumNMHistory.get(i + 7));
+	sb.append(',');
+	sb.append(SleepDeficitHistory.get(i + 7));
+	sb.append(',');
+	sb.append(REMDeficitHistory.get(i + 7));
+	sb.append(',');
+	sb.append(NightmareDistressHistory.get(i));
+	sb.append(',');
+	sb.append(NightmareEffectsHistory.get(i));
+	sb.append(',');
+	sb.append(DASSAnxietyHistory.get(i));
+	sb.append(',');
+	sb.append(MostRecentRegimenHistory.get(i));
+	sb.append('\n');
+
+}
+
+return sb.toString();]]></Body>
+				</Function>
+			</Functions>
 			<AgentLinks>
 				<AgentLink>
 					<Id>1590253624662</Id>
@@ -3102,6 +3649,11 @@ if (HourOfDay >= 24) {
 					<AgentLinkType>COLLECTION_OF_LINKS</AgentLinkType>
 					<AgentLinkBidirectional>true</AgentLinkBidirectional>
 					<MessageType><![CDATA[Object]]></MessageType>
+					<StatechartReference>
+						<PackageName><![CDATA[disturbed_dreaming_model]]></PackageName>
+						<ClassName><![CDATA[Main]]></ClassName>
+						<ItemName><![CDATA[statechart]]></ItemName>
+					</StatechartReference>
 					<LineStyle>SOLID</LineStyle>
 					<LineWidth>1</LineWidth>
 					<LineColor>-16777216</LineColor>
@@ -3171,7 +3723,7 @@ if (HourOfDay >= 24) {
 				<Image>
 					<Id>1590348467618</Id>
 					<Name><![CDATA[image]]></Name>
-					<X>2445</X><Y>65</Y>
+					<X>3095</X><Y>55</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3193,7 +3745,7 @@ if (HourOfDay >= 24) {
 				<Image>
 					<Id>1590348467651</Id>
 					<Name><![CDATA[image1]]></Name>
-					<X>2050</X><Y>75</Y>
+					<X>2700</X><Y>65</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3215,7 +3767,7 @@ if (HourOfDay >= 24) {
 				<Image>
 					<Id>1590348467661</Id>
 					<Name><![CDATA[image2]]></Name>
-					<X>2030</X><Y>330</Y>
+					<X>2680</X><Y>320</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3237,7 +3789,7 @@ if (HourOfDay >= 24) {
 				<Image>
 					<Id>1590348467671</Id>
 					<Name><![CDATA[image3]]></Name>
-					<X>2046</X><Y>526</Y>
+					<X>2696</X><Y>516</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3259,7 +3811,7 @@ if (HourOfDay >= 24) {
 				<Text>
 					<Id>1590348467681</Id>
 					<Name><![CDATA[text2]]></Name>
-					<X>2076</X><Y>516</Y>
+					<X>2726</X><Y>506</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3280,7 +3832,7 @@ if (HourOfDay >= 24) {
 				<Text>
 					<Id>1590348467683</Id>
 					<Name><![CDATA[text3]]></Name>
-					<X>2085</X><Y>325</Y>
+					<X>2735</X><Y>315</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3301,7 +3853,7 @@ if (HourOfDay >= 24) {
 				<Image>
 					<Id>1590348467685</Id>
 					<Name><![CDATA[image4]]></Name>
-					<X>2301</X><Y>546</Y>
+					<X>2951</X><Y>536</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3323,7 +3875,7 @@ if (HourOfDay >= 24) {
 				<Text>
 					<Id>1590348503337</Id>
 					<Name><![CDATA[text4]]></Name>
-					<X>2065</X><Y>40</Y>
+					<X>2715</X><Y>30</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3344,7 +3896,7 @@ if (HourOfDay >= 24) {
 				<Image>
 					<Id>1590348574750</Id>
 					<Name><![CDATA[image5]]></Name>
-					<X>2471</X><Y>521</Y>
+					<X>3121</X><Y>511</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -3366,7 +3918,7 @@ if (HourOfDay >= 24) {
 				<Text>
 					<Id>1590348777741</Id>
 					<Name><![CDATA[text5]]></Name>
-					<X>2391</X><Y>316</Y>
+					<X>3041</X><Y>306</Y>
 					<Label><X>0</X><Y>-10</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -4012,7 +4564,7 @@ provides another important dimension to the data.]]></Text>
 				<Group>
 					<Id>1591106939004</Id>
 					<Name><![CDATA[group10]]></Name>
-					<X>650</X><Y>1370</Y>
+					<X>635</X><Y>1885</Y>
 					<Label><X>10</X><Y>0</Y></Label>
 					<PublicFlag>true</PublicFlag>
 					<PresentationFlag>true</PresentationFlag>
@@ -4162,7 +4714,7 @@ provides another important dimension to the data.]]></Text>
 					<LineMaterial>null</LineMaterial>
 					<LineStyle>SOLID</LineStyle>
 					<Width>190</Width>
-					<Height>250</Height>
+					<Height>280</Height>
 					<Rotation>0.0</Rotation>
 					<FillColor>-1</FillColor>
 					<FillMaterial>null</FillMaterial>
@@ -4192,6 +4744,114 @@ provides another important dimension to the data.]]></Text>
 			</Presentation>
 
 				</Group>
+				<Text>
+					<Id>1594234009015</Id>
+					<Name><![CDATA[testOutput]]></Name>
+					<X>990</X><Y>1090</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[TestOutput]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>14</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Rectangle>
+					<Id>1594235639725</Id>
+					<Name><![CDATA[test_color]]></Name>
+					<X>900</X><Y>1080</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>80</Width>
+					<Height>60</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+				</Rectangle>
+				<RoundedRectangle>
+					<Id>1594236975330</Id>
+					<Name><![CDATA[roundRectangle14]]></Name>
+					<X>620</X><Y>1180</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>190</Width>
+					<Height>180</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594237035442</Id>
+					<Name><![CDATA[text9]]></Name>
+					<X>720</X><Y>1180</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Tracking methods]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Text>
+					<Id>1594321137798</Id>
+					<Name><![CDATA[text_inputValidation]]></Name>
+					<X>860</X><Y>380</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Input Validation]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
 			</Presentation>
 
 				</Level>
@@ -4207,8 +4867,8 @@ provides another important dimension to the data.]]></Text>
 	<RelativeAccuracy>1.0E-5</RelativeAccuracy>
 	<TimeAccuracy>1.0E-5</TimeAccuracy>
 	<Frame>
-		<Width>2000</Width>
-		<Height>1200</Height>
+		<Width>2620</Width>
+		<Height>1490</Height>
 	</Frame>
 	<Database>
 		<Logging>false</Logging>
@@ -4299,7 +4959,7 @@ provides another important dimension to the data.]]></Text>
 				<Parameter>
 					<ParameterName><![CDATA[FearExtinctionFailureThreshold]]></ParameterName>
 					<ParameterValue Class="CodeValue">
-						<Code><![CDATA[1]]></Code>
+						<Code><![CDATA[1.1]]></Code>
 					</ParameterValue>
 				</Parameter>
 				<Parameter>
@@ -4354,12 +5014,6 @@ provides another important dimension to the data.]]></Text>
 					</ParameterValue>
 				</Parameter>
 				<Parameter>
-					<ParameterName><![CDATA[FearExtinctionCompletionThreshold]]></ParameterName>
-					<ParameterValue Class="CodeValue">
-						<Code><![CDATA[1]]></Code>
-					</ParameterValue>
-				</Parameter>
-				<Parameter>
 					<ParameterName><![CDATA[ImageStabilizationCapacity]]></ParameterName>
 					<ParameterValue Class="CodeValue">
 						<Code><![CDATA[1]]></Code>
@@ -4368,7 +5022,7 @@ provides another important dimension to the data.]]></Text>
 				<Parameter>
 					<ParameterName><![CDATA[FearExtinctionAttemptThreshold]]></ParameterName>
 					<ParameterValue Class="CodeValue">
-						<Code><![CDATA[1]]></Code>
+						<Code><![CDATA[0.9]]></Code>
 					</ParameterValue>
 				</Parameter>
 				<Parameter>
@@ -4428,6 +5082,12 @@ provides another important dimension to the data.]]></Text>
 						<Code><![CDATA[1]]></Code>
 					</ParameterValue>
 				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TimeInState]]></ParameterName>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ExperimentId]]></ParameterName>
+				</Parameter>
 			</Parameters>			
 			<PresentationProperties>
 				<EnableZoomAndPanning>true</EnableZoomAndPanning>
@@ -4444,8 +5104,5069 @@ provides another important dimension to the data.]]></Text>
 				<FinalDate><![CDATA[1592870400000]]></FinalDate>	
 				<FinalTime><![CDATA[100.0]]></FinalTime>	
 			</ModelTimeProperties>
-		</SimulationExperiment>	
+		</SimulationExperiment>
+		<!--   =========   Simulation Experiment   ========  -->
+		<SimulationExperiment ActiveObjectClassId="1590253624667">
+			<Id>1594231814301</Id>
+			<Name><![CDATA[Tests_SingleNight]]></Name>
+			<ClientAreaTopLeft><X>0</X><Y>0</Y></ClientAreaTopLeft>
+			<Import><![CDATA[import java.util.function.*;]]></Import>
+			<CommandLineArguments><![CDATA[]]></CommandLineArguments>
+			<InitialSetupCode><![CDATA[setDefaults();]]></InitialSetupCode>
+			<MaximumMemory>512</MaximumMemory>
+			<RandomNumberGenerationType>fixedSeed</RandomNumberGenerationType>
+			<CustomGeneratorCode>new Random()</CustomGeneratorCode>
+			<AfterSimulationRunCode><![CDATA[root.DisplayTestResult(checkTestsFunction.apply(root));]]></AfterSimulationRunCode>
+			<SeedValue>1</SeedValue>
+			<SelectionModeForSimultaneousEvents>LIFO</SelectionModeForSimultaneousEvents>
+			<VmArgs><![CDATA[]]></VmArgs>
+			<LoadRootFromSnapshot>false</LoadRootFromSnapshot>
+			<Variables>
+				<Variable Class="PlainVariable">
+					<Id>1594232142745</Id>
+					<Name><![CDATA[AffectDistressTendency]]></Name>
+					<X>640</X><Y>120</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232242563</Id>
+					<Name><![CDATA[TraumaHistory]]></Name>
+					<X>640</X><Y>150</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232253903</Id>
+					<Name><![CDATA[FearExtinctionFailureThreshold]]></Name>
+					<X>630</X><Y>720</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232267576</Id>
+					<Name><![CDATA[ImageValence]]></Name>
+					<X>640</X><Y>300</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232328406</Id>
+					<Name><![CDATA[InitialAffectLoad]]></Name>
+					<X>640</X><Y>180</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232336995</Id>
+					<Name><![CDATA[Lucidity]]></Name>
+					<X>640</X><Y>210</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232345371</Id>
+					<Name><![CDATA[ImageStabilizationCapacity]]></Name>
+					<X>640</X><Y>240</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232365300</Id>
+					<Name><![CDATA[ImageDominance]]></Name>
+					<X>640</X><Y>330</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232375915</Id>
+					<Name><![CDATA[ImageArousal]]></Name>
+					<X>640</X><Y>360</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232386684</Id>
+					<Name><![CDATA[MaxREMCyclesPerNight]]></Name>
+					<X>640</X><Y>420</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232403191</Id>
+					<Name><![CDATA[MaxHoursSleepPerNight]]></Name>
+					<X>640</X><Y>450</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232413873</Id>
+					<Name><![CDATA[IdealHoursSleepPerNight]]></Name>
+					<X>640</X><Y>480</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232424889</Id>
+					<Name><![CDATA[NormalSleepHour]]></Name>
+					<X>640</X><Y>510</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232435786</Id>
+					<Name><![CDATA[NTNMAffectLoadIncrement]]></Name>
+					<X>640</X><Y>540</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232456333</Id>
+					<Name><![CDATA[FearExtinctionAttemptThreshold]]></Name>
+					<X>630</X><Y>660</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232503900</Id>
+					<Name><![CDATA[DandRFailureThreshold]]></Name>
+					<X>630</X><Y>690</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232555805</Id>
+					<Name><![CDATA[FearExtinctionCompletionThreshold]]></Name>
+					<X>630</X><Y>750</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232568277</Id>
+					<Name><![CDATA[PostNightmareSleepThreshold]]></Name>
+					<X>630</X><Y>780</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232580706</Id>
+					<Name><![CDATA[TreatmentDegreesOfControl]]></Name>
+					<X>640</X><Y>830</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232589870</Id>
+					<Name><![CDATA[TreatmentImagesSimilarToNM]]></Name>
+					<X>640</X><Y>860</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232601327</Id>
+					<Name><![CDATA[AdrenalineAntagonists]]></Name>
+					<X>640</X><Y>890</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232612405</Id>
+					<Name><![CDATA[TreatmentFrequency]]></Name>
+					<X>640</X><Y>920</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232625694</Id>
+					<Name><![CDATA[TreatmentType]]></Name>
+					<X>640</X><Y>950</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232895162</Id>
+					<Name><![CDATA[TNMAffectLoadIncrement]]></Name>
+					<X>640</X><Y>570</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594232916163</Id>
+					<Name><![CDATA[FEAffectLoadDecrement]]></Name>
+					<X>640</X><Y>600</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594235059957</Id>
+					<Name><![CDATA[checkTestsFunction]]></Name>
+					<X>560</X><Y>1320</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[Function<Main, TestResult>]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[null;]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
+			</Variables>
+			<Functions>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594234858622</Id>
+					<Name><![CDATA[setDefaults]]></Name>
+					<X>560</X><Y>1230</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[AffectDistressTendency = 0.5;
+TraumaHistory = 0.5;
+InitialAffectLoad = 0.5;
+Lucidity = 0.5;
+ImageStabilizationCapacity = 0.5;
+
+ImageValence = 0;
+ImageDominance = 0;
+ImageArousal = 0;
+
+MaxREMCyclesPerNight = 4;
+MaxHoursSleepPerNight = 8;
+IdealHoursSleepPerNight = 8;
+NormalSleepHour = 22;
+NTNMAffectLoadIncrement = 0.005;
+TNMAffectLoadIncrement = 0.01;
+FEAffectLoadDecrement = 0.01;
+
+FearExtinctionAttemptThreshold = 0.5;
+DandRFailureThreshold = 0.5;
+FearExtinctionFailureThreshold = 0.5;
+FearExtinctionCompletionThreshold = 0.5;
+PostNightmareSleepThreshold = 0.5;
+
+TreatmentDegreesOfControl = 0.5;
+TreatmentImagesSimilarToNM = 0.5;
+AdrenalineAntagonists = 0.5;
+TreatmentFrequency = 1;
+TreatmentType = 0;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594235059949</Id>
+					<Name><![CDATA[equals]]></Name>
+					<X>560</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[l1]]></Name>
+						<Type><![CDATA[List<Main.statechart_state>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[l2]]></Name>
+						<Type><![CDATA[List<Main.statechart_state>]]></Type>
+					</Parameter>
+					<Body><![CDATA[int i = 0;
+
+while (i < l1.size() && i < l2.size() && l1.get(i).equals(l2.get(i))) {
+	i++;
+}
+
+if (i == l1.size() && i == l2.size()) {
+	return null;
+} else if (i == l1.size()) {
+	return "NOT EQUAL. The lists are equal up until the completion of list 1.";
+} else if (i == l2.size()) {
+	return "NOT EQUAL. The lists are equal up until the completion of list 2.";
+} else {
+	return "NOT EQUAL. This lists are equal up until index " + i;
+}]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594394992198</Id>
+					<Name><![CDATA[equalsDouble]]></Name>
+					<X>650</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[o1]]></Name>
+						<Type><![CDATA[double]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[o2]]></Name>
+						<Type><![CDATA[double]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[s]]></Name>
+						<Type><![CDATA[String]]></Type>
+					</Parameter>
+					<Body><![CDATA[return o1 == o2? "" : s;]]></Body>
+				</Function>
+			</Functions>
+
+			<Presentation>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594232950974</Id>
+					<Name><![CDATA[button_defaults]]></Name>
+					<X>40</X><Y>1640</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="200" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Reset to defaults]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594235090230</Id>
+					<Name><![CDATA[button_test1]]></Name>
+					<X>40</X><Y>130</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="200" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+ImageValence = 1;
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+InitialAffectLoad = 1;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.DepotentiatedImages));
+	
+	
+	return errorMessage == null 
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Immediate Depotentiated]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Group>
+					<Id>1594237115126</Id>
+					<Name><![CDATA[group3]]></Name>
+					<X>674.5</X><Y>294.5</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594237115128</Id>
+					<Name><![CDATA[roundRectangle]]></Name>
+					<X>-134.5</X><Y>-203.98</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>167.109</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594237115130</Id>
+					<Name><![CDATA[text6]]></Name>
+					<X>-51.73</X><Y>-203.98</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Personal Factors]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594237115137</Id>
+					<Name><![CDATA[group4]]></Name>
+					<X>730</X><Y>310</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594237115139</Id>
+					<Name><![CDATA[roundRectangle1]]></Name>
+					<X>-190</X><Y>-40</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>120</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594237115141</Id>
+					<Name><![CDATA[text7]]></Name>
+					<X>-110</X><Y>-40</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Image Qualities]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594237115143</Id>
+					<Name><![CDATA[group5]]></Name>
+					<X>730</X><Y>440</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594237115145</Id>
+					<Name><![CDATA[roundRectangle2]]></Name>
+					<X>-190</X><Y>-50</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>230</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594237115147</Id>
+					<Name><![CDATA[text15]]></Name>
+					<X>-110</X><Y>-50</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Sleep Factors]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594237115155</Id>
+					<Name><![CDATA[group7]]></Name>
+					<X>740</X><Y>860</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594237115157</Id>
+					<Name><![CDATA[roundRectangle4]]></Name>
+					<X>-200</X><Y>-60</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>170</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594237115159</Id>
+					<Name><![CDATA[text8]]></Name>
+					<X>-110</X><Y>-60</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Treatment Parameters]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594237197740</Id>
+					<Name><![CDATA[group8]]></Name>
+					<X>630</X><Y>440</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594237197742</Id>
+					<Name><![CDATA[roundRectangle5]]></Name>
+					<X>-90</X><Y>190</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>160</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594237197744</Id>
+					<Name><![CDATA[text17]]></Name>
+					<X>-10</X><Y>190</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Thresholds]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Text>
+					<Id>1594237369681</Id>
+					<Name><![CDATA[text]]></Name>
+					<X>40</X><Y>20</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Run a test by resetting the parameters to defaults, then clicking a test to select that test to run.
+Then, run the simulation, and check the test output to see if the test passed.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Text>
+					<Id>1594237405172</Id>
+					<Name><![CDATA[text1]]></Name>
+					<X>40</X><Y>190</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Test immediate depontentiated from high image valence.
+Even with trauma and a high affect load, high valence images are immediately depotentiated
+with no fear extinction.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594239837245</Id>
+					<Name><![CDATA[button_test4]]></Name>
+					<X>40</X><Y>260</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 1;
+FEAffectLoadDecrement = 0.15;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.EventMemoryImagesInSleep,
+						Main.DepotentiatedImages));
+	
+	
+	return errorMessage == null 
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Fear extinction after one REM cycle : 1 fear extinctions]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594239837250</Id>
+					<Name><![CDATA[text4]]></Name>
+					<X>40</X><Y>320</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Test recontexutalization successful on firstattempt.
+Make the image scary and person vulnerable, but keep initial affect loads
+between thresholds so that first depotentiating attempt succeeds partially,
+resulting in an affect load decrement. On the second attempt,
+depontiation is successful.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594239928853</Id>
+					<Name><![CDATA[button_test5]]></Name>
+					<X>40</X><Y>530</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 0.1;
+FEAffectLoadDecrement = 0.15;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages));
+	
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	errorMessage = "";
+	if (root.HoursSleepHistory.get(root.HoursSleepHistory.size() - 1) != 6) {
+		errorMessage += "HoursSleepTonight: 6 != " + root.HoursSleepTonight + "\n";
+	}
+	
+	if (root.REMPeriodsHistory.get(root.REMPeriodsHistory.size() - 1) != 0) {
+		errorMessage += "REMPeriodsTonight: 0 != " + (root.REMPeriodsHistory.size() - 1) + "\n";
+	}
+	
+	if (root.NonTraumNMHistory.get(root.NonTraumNMHistory.size() - 1) != 3) {
+		errorMessage += "NonTraumNM: 3 != " + (root.NonTraumNMHistory.size() - 1) + "\n";
+	}
+	
+	if (root.HourOfDay != (22 + 15) % 24) {
+		errorMessage += String.format("HourOfDay: %d != %d\n", (22 + 15) % 24, root.REMPeriodsTonight);
+	}
+	
+	if (root.HourOfRun != 15) {
+		errorMessage += String.format("HourOfRun: %d != %d\n", 15, root.REMPeriodsTonight);
+	}
+	
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Non Traum NM Wake cycle: Wake after night]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594239928859</Id>
+					<Name><![CDATA[text5]]></Name>
+					<X>40</X><Y>590</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Cycle of NonTraumatic nightmares resulting in waking and
+no REM cycles]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594241587450</Id>
+					<Name><![CDATA[button_test6]]></Name>
+					<X>40</X><Y>860</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 0.1;
+FEAffectLoadDecrement = 0.15;
+DandRFailureThreshold = 0.1;
+PostNightmareSleepThreshold = 1;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.AwakeImageAwareness,
+						Main.EventMemoryImagesInSleep,
+						Main.AwakeImageAwareness,
+						Main.EventMemoryImagesInSleep,
+						Main.AwakeImageAwareness,
+						Main.EventMemoryImagesInSleep,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages));
+	
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	errorMessage = "";
+	if (root.HoursSleepHistory.get(root.HoursSleepHistory.size() - 1) != 4) {
+		errorMessage += "HoursSleepTonight: 4 != " + root.HoursSleepTonight + "\n";
+	}
+	
+	if (root.REMPeriodsHistory.get(root.REMPeriodsHistory.size() - 1) != 0) {
+		errorMessage += "REMPeriodsTonight: 0 != " + root.REMPeriodsTonight + "\n";
+	}
+	
+	if (root.NonTraumNMHistory.get(root.TraumNMHistory.size() - 1) != 4) {
+		errorMessage += "TraumNM: 4 != " + (root.TraumNMHistory.size() - 1) + "\n";
+	}
+	
+	if (root.HourOfDay != (22 + 15) % 24) {
+		errorMessage += String.format("HourOfDay: %d != %d\n", (22 + 15) % 24, root.REMPeriodsTonight);
+	}
+	
+	if (root.HourOfRun != 15) {
+		errorMessage += String.format("HourOfRun: %d != %d\n", 15, root.REMPeriodsTonight);
+	}
+	
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Traum NM Wake cycle : Wake after night]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594241587459</Id>
+					<Name><![CDATA[text9]]></Name>
+					<X>40</X><Y>920</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Cycle of Traumatic nightmares resulting in waking and
+no REM cycles.
+After some nightmares, the person wakes up because the night
+is over.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594321994625</Id>
+					<Name><![CDATA[button_test7]]></Name>
+					<X>47</X><Y>648</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 0.1;
+FEAffectLoadDecrement = 0.15;
+PostNightmareSleepThreshold = 0.2;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages));
+	
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	errorMessage = "";
+	if (root.HoursSleepHistory.get(root.HoursSleepHistory.size() - 1) != 2) {
+		errorMessage += "HoursSleepTonight: 2 != " + root.HoursSleepTonight + "\n";
+	}
+	
+	if (root.REMPeriodsHistory.get(root.REMPeriodsHistory.size() - 1) != 0) {
+		errorMessage += "REMPeriodsTonight: 0 != " + (root.REMPeriodsHistory.size() - 1) + "\n";
+	}
+	
+	if (root.NonTraumNMHistory.get(root.NonTraumNMHistory.size() - 1) != 1) {
+		errorMessage += "NonTraumNM: 1 != " + (root.NonTraumNMHistory.size() - 1) + "\n";
+	}
+	
+	if (root.HourOfDay != (22 + 15) % 24) {
+		errorMessage += String.format("HourOfDay: %d != %d\n", (22 + 15) % 24, root.REMPeriodsTonight);
+	}
+	
+	if (root.HourOfRun != 15) {
+		errorMessage += String.format("HourOfRun: %d != %d\n", 15, root.REMPeriodsTonight);
+	}
+	
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Non Traum NM Wake cycle: Wake from after first nightmare]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594321994633</Id>
+					<Name><![CDATA[text10]]></Name>
+					<X>47</X><Y>708</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Cycle of NonTraumatic nightmares accumulates fear
+ resulting in waking and no REM cycles]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594322244008</Id>
+					<Name><![CDATA[button_test8]]></Name>
+					<X>37</X><Y>758</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 0.1;
+FEAffectLoadDecrement = 0.15;
+PostNightmareSleepThreshold = 0.34; // One nightmare brings fear up to 0.33
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages));
+	
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	errorMessage = "";
+	if (root.HoursSleepHistory.get(root.HoursSleepHistory.size() - 1) != 4) {
+		errorMessage += "HoursSleepTonight: 2 != " + root.HoursSleepTonight + "\n";
+	}
+	
+	if (root.REMPeriodsHistory.get(root.REMPeriodsHistory.size() - 1) != 0) {
+		errorMessage += "REMPeriodsTonight: 0 != " + (root.REMPeriodsHistory.size() - 1) + "\n";
+	}
+	
+	if (root.NonTraumNMHistory.get(root.NonTraumNMHistory.size() - 1) != 2) {
+		errorMessage += "NonTraumNM: 1 != " + (root.NonTraumNMHistory.size() - 1) + "\n";
+	}
+	
+	if (root.HourOfDay != (22 + 15) % 24) {
+		errorMessage += String.format("HourOfDay: %d != %d\n", (22 + 15) % 24, root.REMPeriodsTonight);
+	}
+	
+	if (root.HourOfRun != 15) {
+		errorMessage += String.format("HourOfRun: %d != %d\n", 15, root.REMPeriodsTonight);
+	}
+	
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Non Traum NM Wake cycle: Wake from after second nightmare]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594322244014</Id>
+					<Name><![CDATA[text11]]></Name>
+					<X>37</X><Y>818</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Cycle of NonTraumatic nightmares accumulates fear
+ resulting in waking and no REM cycles]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594322824816</Id>
+					<Name><![CDATA[button_test9]]></Name>
+					<X>40</X><Y>980</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 0.1;
+FEAffectLoadDecrement = 0.15;
+DandRFailureThreshold = 0.1;
+PostNightmareSleepThreshold = 0.3;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages));
+	
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	errorMessage = "";
+	if (root.HoursSleepHistory.get(root.HoursSleepHistory.size() - 1) != 1) {
+		errorMessage += "HoursSleepTonight: 1 != " + root.HoursSleepTonight + "\n";
+	}
+	
+	if (root.REMPeriodsHistory.get(root.REMPeriodsHistory.size() - 1) != 0) {
+		errorMessage += "REMPeriodsTonight: 0 != " + root.REMPeriodsTonight + "\n";
+	}
+	
+	if (root.NonTraumNMHistory.get(root.TraumNMHistory.size() - 1) != 1) {
+		errorMessage += "TraumNM: 1 != " + (root.TraumNMHistory.size() - 1) + "\n";
+	}
+	
+	if (root.HourOfDay != (22 + 15) % 24) {
+		errorMessage += String.format("HourOfDay: %d != %d\n", (22 + 15) % 24, root.REMPeriodsTonight);
+	}
+	
+	if (root.HourOfRun != 15) {
+		errorMessage += String.format("HourOfRun: %d != %d\n", 15, root.REMPeriodsTonight);
+	}
+	
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Traum NM Wake cycle : Wake after first NM]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594322824822</Id>
+					<Name><![CDATA[text12]]></Name>
+					<X>40</X><Y>1040</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Cycle of Traumatic nightmares resulting in waking and
+no REM cycles.
+After one nightmares, the person wakes up from fear and stay awake.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594322979767</Id>
+					<Name><![CDATA[button_test10]]></Name>
+					<X>40</X><Y>1110</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 0.1;
+FEAffectLoadDecrement = 0.15;
+DandRFailureThreshold = 0.1;
+PostNightmareSleepThreshold = 0.35;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.AwakeImageAwareness,
+						Main.EventMemoryImagesInSleep,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages));
+	
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	errorMessage = "";
+	if (root.HoursSleepHistory.get(root.HoursSleepHistory.size() - 1) != 2) {
+		errorMessage += "HoursSleepTonight: 1 != " + root.HoursSleepTonight + "\n";
+	}
+	
+	if (root.REMPeriodsHistory.get(root.REMPeriodsHistory.size() - 1) != 0) {
+		errorMessage += "REMPeriodsTonight: 0 != " + root.REMPeriodsTonight + "\n";
+	}
+	
+	if (root.NonTraumNMHistory.get(root.TraumNMHistory.size() - 1) != 2) {
+		errorMessage += "TraumNM: 2 != " + (root.TraumNMHistory.size() - 1) + "\n";
+	}
+	
+	if (root.HourOfDay != (22 + 15) % 24) {
+		errorMessage += String.format("HourOfDay: %d != %d\n", (22 + 15) % 24, root.REMPeriodsTonight);
+	}
+	
+	if (root.HourOfRun != 15) {
+		errorMessage += String.format("HourOfRun: %d != %d\n", 15, root.REMPeriodsTonight);
+	}
+	
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Traum NM Wake cycle : Wake after second NM]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594322979776</Id>
+					<Name><![CDATA[text13]]></Name>
+					<X>40</X><Y>1170</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Cycle of Traumatic nightmares resulting in waking and
+no REM cycles.
+After two nightmares, the person wakes up from fear and stay awake.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594323795359</Id>
+					<Name><![CDATA[button_test11]]></Name>
+					<X>42</X><Y>398</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 1;
+FEAffectLoadDecrement = 0.0000001;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages));
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	errorMessage = "";
+	if (root.HoursSleepHistory.get(root.HoursSleepHistory.size() - 1) != 8) {
+		errorMessage += "HoursSleepTonight: 8 != " + root.HoursSleepTonight + "\n";
+	}
+	
+	if (root.REMPeriodsHistory.get(root.REMPeriodsHistory.size() - 1) != 4) {
+		errorMessage += "REMPeriodsTonight: 4 != " + (root.REMPeriodsHistory.size() - 1) + "\n";
+	}
+	
+	if (root.NonTraumNMHistory.get(root.NonTraumNMHistory.size() - 1) != 0) {
+		errorMessage += "NonTraumNM: 0 != " + (root.NonTraumNMHistory.size() - 1) + "\n";
+	}
+	
+	if (root.HourOfDay != (22 + 15) % 24) {
+		errorMessage += String.format("HourOfDay: %d != %d\n", (22 + 15) % 24, root.REMPeriodsTonight);
+	}
+	
+	if (root.HourOfRun != 15) {
+		errorMessage += String.format("HourOfRun: %d != %d\n", 15, root.REMPeriodsTonight);
+	}
+	
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Fear extinction partial all night then wake]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594323795366</Id>
+					<Name><![CDATA[text14]]></Name>
+					<X>42</X><Y>458</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Test recontexutalization successful on firstattempt.
+Make the image scary and person vulnerable, but keep initial affect loads
+between thresholds so that first depotentiating attempt succeeds partially,
+resulting in an affect load decrement. This happens all night until waking.
+No nightmares occur.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594394861023</Id>
+					<Name><![CDATA[button_test12]]></Name>
+					<X>40</X><Y>1230</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[AffectDistressTendency = 0.01;
+TraumaHistory = 0.02;
+InitialAffectLoad = 0.03;
+Lucidity = 0.04;
+ImageStabilizationCapacity = 0.05;
+
+ImageValence = 0.06;
+ImageDominance = 0.07;
+ImageArousal = 0.08;
+
+MaxREMCyclesPerNight = 4;
+MaxHoursSleepPerNight = 8;
+IdealHoursSleepPerNight = 7;
+NormalSleepHour = 22;
+NTNMAffectLoadIncrement = 0.09;
+TNMAffectLoadIncrement = 0.10;
+FEAffectLoadDecrement = 0.11;
+
+FearExtinctionAttemptThreshold = 0.12;
+DandRFailureThreshold = 0.13;
+FearExtinctionFailureThreshold = 0.14;
+FearExtinctionCompletionThreshold = 0.15;
+PostNightmareSleepThreshold = 0.16;
+
+TreatmentDegreesOfControl = 0.17;
+TreatmentImagesSimilarToNM = 0.18;
+AdrenalineAntagonists = 0.19;
+TreatmentFrequency = 1;
+TreatmentType = 0;
+checkTestsFunction = root -> {
+	String[] headers = root.GetHeaders().split(",");
+	String[] outputs = root.GetOutput().split(",");
+	
+	String errorMessage = "";
+	errorMessage += equalsDouble(headers.length, outputs.length, "Length");
+
+	errorMessage += equalsDouble(root.AffectDistressTendency, AffectDistressTendency, "AffectDistressTendency");
+	errorMessage += equalsDouble(root.TraumaHistory, TraumaHistory, "TraumaHistory");
+	errorMessage += equalsDouble(root.InitialAffectLoad, InitialAffectLoad, "InitialAffectLoad");
+	errorMessage += equalsDouble(root.Lucidity, Lucidity, "Lucidity");
+	errorMessage += equalsDouble(root.ImageStabilizationCapacity, ImageStabilizationCapacity, "ImageStabilizationCapacity");
+	errorMessage += equalsDouble(root.ImageValence, ImageValence, "ImageValence");
+	errorMessage += equalsDouble(root.ImageDominance, ImageDominance, "ImageDominance");
+	errorMessage += equalsDouble(root.ImageArousal, ImageArousal, "ImageArousal");
+	errorMessage += equalsDouble(root.MaxREMCyclesPerNight, MaxREMCyclesPerNight, "MaxREMCyclesPerNight");
+	errorMessage += equalsDouble(root.MaxHoursSleepPerNight, MaxHoursSleepPerNight, "MaxHoursSleepPerNight");
+	errorMessage += equalsDouble(root.IdealHoursSleepPerNight, IdealHoursSleepPerNight, "IdealHoursSleepPerNight");
+	errorMessage += equalsDouble(root.NormalSleepHour, NormalSleepHour, "NormalSleepHour");
+	errorMessage += equalsDouble(root.NTNMAffectLoadIncrement, NTNMAffectLoadIncrement, "NTNMAffectLoadIncrement");
+	errorMessage += equalsDouble(root.TNMAffectLoadIncrement, TNMAffectLoadIncrement, "TNMAffectLoadIncrement");
+	errorMessage += equalsDouble(root.FEAffectLoadDecrement, FEAffectLoadDecrement, "FEAffectLoadDecrement");
+	errorMessage += equalsDouble(root.FearExtinctionAttemptThreshold, FearExtinctionAttemptThreshold, "FearExtinctionAttemptThreshold");
+	errorMessage += equalsDouble(root.DandRFailureThreshold, DandRFailureThreshold, "DandRFailureThreshold");
+	errorMessage += equalsDouble(root.FearExtinctionFailureThreshold, FearExtinctionFailureThreshold, "FearExtinctionFailureThreshold");
+	errorMessage += equalsDouble(root.PostNightmareSleepThreshold, PostNightmareSleepThreshold, "PostNightmareSleepThreshold");
+	errorMessage += equalsDouble(root.TreatmentDegreeOfControl, TreatmentDegreesOfControl, "TreatmentDegreesOfControl");
+	errorMessage += equalsDouble(root.TreatmentImagesSimilarToNM, TreatmentImagesSimilarToNM, "TreatmentImagesSimilarToNM");
+	errorMessage += equalsDouble(root.AdrenalineAntagonists, AdrenalineAntagonists, "AdrenalineAntagonists");
+	errorMessage += equalsDouble(root.TreatmentFrequency, TreatmentFrequency, "TreatmentFrequency");
+	errorMessage += equalsDouble(root.TreatmentType, TreatmentType, "TreatmentType");
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Test output]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+			</Presentation>
+
+			<Parameters>			
+				<Parameter>
+					<ParameterName><![CDATA[AffectDistressTendency]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[AffectDistressTendency]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TraumaHistory]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TraumaHistory]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[FearExtinctionFailureThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[FearExtinctionFailureThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageValence]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageValence]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageArousal]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageArousal]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageDominance]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageDominance]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[InitialAffectLoad]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[InitialAffectLoad]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentDegreeOfControl]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentDegreesOfControl]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentImagesSimilarToNM]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentImagesSimilarToNM]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[AdrenalineAntagonists]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[AdrenalineAntagonists]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentFrequency]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentFrequency]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentType]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentType]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageStabilizationCapacity]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageStabilizationCapacity]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[FearExtinctionAttemptThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[FearExtinctionAttemptThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[DandRFailureThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[DandRFailureThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[MaxREMCyclesPerNight]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[MaxREMCyclesPerNight]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[MaxHoursSleepPerNight]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[MaxHoursSleepPerNight]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[IdealHoursSleepPerNight]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[IdealHoursSleepPerNight]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[FEAffectLoadDecrement]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[FEAffectLoadDecrement]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[PostNightmareSleepThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[PostNightmareSleepThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[NormalSleepHour]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[NormalSleepHour]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[NTNMAffectLoadIncrement]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[NTNMAffectLoadIncrement]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TNMAffectLoadIncrement]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TNMAffectLoadIncrement]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[Lucidity]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[Lucidity]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TimeInState]]></ParameterName>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ExperimentId]]></ParameterName>
+				</Parameter>
+			</Parameters>			
+			<PresentationProperties>
+				<EnableZoomAndPanning>true</EnableZoomAndPanning>
+				<ExecutionMode><![CDATA[virtualTime]]></ExecutionMode>
+				<Title><![CDATA[Disturbed Dreaming Model : Tests]]></Title>	
+				<EnableDeveloperPanel>true</EnableDeveloperPanel>
+				<ShowDeveloperPanelOnStart>false</ShowDeveloperPanelOnStart>
+				<RealTimeScale>0.1</RealTimeScale>
+			</PresentationProperties>
+			<ModelTimeProperties>
+				<StopOption><![CDATA[Stop at specified time]]></StopOption>
+				<InitialDate><![CDATA[1590192000000]]></InitialDate>	
+				<InitialTime><![CDATA[0.0]]></InitialTime>	
+				<FinalDate><![CDATA[1590246000000]]></FinalDate>	
+				<FinalTime><![CDATA[15.0]]></FinalTime>	
+			</ModelTimeProperties>
+		</SimulationExperiment>
+		<!--   =========   Simulation Experiment   ========  -->
+		<SimulationExperiment ActiveObjectClassId="1590253624667">
+			<Id>1594324367115</Id>
+			<Name><![CDATA[Tests_TwoNights]]></Name>
+			<ClientAreaTopLeft><X>0</X><Y>0</Y></ClientAreaTopLeft>
+			<Import><![CDATA[import java.util.function.*;]]></Import>
+			<CommandLineArguments><![CDATA[]]></CommandLineArguments>
+			<InitialSetupCode><![CDATA[setDefaults();]]></InitialSetupCode>
+			<MaximumMemory>512</MaximumMemory>
+			<RandomNumberGenerationType>fixedSeed</RandomNumberGenerationType>
+			<CustomGeneratorCode>new Random()</CustomGeneratorCode>
+			<AfterSimulationRunCode><![CDATA[root.DisplayTestResult(checkTestsFunction.apply(root));]]></AfterSimulationRunCode>
+			<SeedValue>1</SeedValue>
+			<SelectionModeForSimultaneousEvents>LIFO</SelectionModeForSimultaneousEvents>
+			<VmArgs><![CDATA[]]></VmArgs>
+			<LoadRootFromSnapshot>false</LoadRootFromSnapshot>
+			<Variables>
+				<Variable Class="PlainVariable">
+					<Id>1594324367121</Id>
+					<Name><![CDATA[AffectDistressTendency]]></Name>
+					<X>640</X><Y>120</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367123</Id>
+					<Name><![CDATA[TraumaHistory]]></Name>
+					<X>640</X><Y>150</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367125</Id>
+					<Name><![CDATA[FearExtinctionFailureThreshold]]></Name>
+					<X>630</X><Y>720</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367127</Id>
+					<Name><![CDATA[ImageValence]]></Name>
+					<X>640</X><Y>300</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367129</Id>
+					<Name><![CDATA[InitialAffectLoad]]></Name>
+					<X>640</X><Y>180</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367131</Id>
+					<Name><![CDATA[Lucidity]]></Name>
+					<X>640</X><Y>210</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367133</Id>
+					<Name><![CDATA[ImageStabilizationCapacity]]></Name>
+					<X>640</X><Y>240</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367135</Id>
+					<Name><![CDATA[ImageDominance]]></Name>
+					<X>640</X><Y>330</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367137</Id>
+					<Name><![CDATA[ImageArousal]]></Name>
+					<X>640</X><Y>360</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367139</Id>
+					<Name><![CDATA[MaxREMCyclesPerNight]]></Name>
+					<X>640</X><Y>420</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367141</Id>
+					<Name><![CDATA[MaxHoursSleepPerNight]]></Name>
+					<X>640</X><Y>450</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367143</Id>
+					<Name><![CDATA[IdealHoursSleepPerNight]]></Name>
+					<X>640</X><Y>480</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367145</Id>
+					<Name><![CDATA[NormalSleepHour]]></Name>
+					<X>640</X><Y>510</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367147</Id>
+					<Name><![CDATA[NTNMAffectLoadIncrement]]></Name>
+					<X>640</X><Y>540</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367149</Id>
+					<Name><![CDATA[FearExtinctionAttemptThreshold]]></Name>
+					<X>630</X><Y>660</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367151</Id>
+					<Name><![CDATA[DandRFailureThreshold]]></Name>
+					<X>630</X><Y>690</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367153</Id>
+					<Name><![CDATA[FearExtinctionCompletionThreshold]]></Name>
+					<X>630</X><Y>750</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367155</Id>
+					<Name><![CDATA[PostNightmareSleepThreshold]]></Name>
+					<X>630</X><Y>780</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367157</Id>
+					<Name><![CDATA[TreatmentDegreesOfControl]]></Name>
+					<X>640</X><Y>830</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367159</Id>
+					<Name><![CDATA[TreatmentImagesSimilarToNM]]></Name>
+					<X>640</X><Y>860</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367161</Id>
+					<Name><![CDATA[AdrenalineAntagonists]]></Name>
+					<X>640</X><Y>890</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367163</Id>
+					<Name><![CDATA[TreatmentFrequency]]></Name>
+					<X>640</X><Y>920</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367165</Id>
+					<Name><![CDATA[TreatmentType]]></Name>
+					<X>640</X><Y>950</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367167</Id>
+					<Name><![CDATA[TNMAffectLoadIncrement]]></Name>
+					<X>640</X><Y>570</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367169</Id>
+					<Name><![CDATA[FEAffectLoadDecrement]]></Name>
+					<X>640</X><Y>600</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594324367171</Id>
+					<Name><![CDATA[checkTestsFunction]]></Name>
+					<X>560</X><Y>1320</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[Function<Main, TestResult>]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[null;]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
+			</Variables>
+			<Functions>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594324367117</Id>
+					<Name><![CDATA[setDefaults]]></Name>
+					<X>560</X><Y>1230</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[AffectDistressTendency = 0.5;
+TraumaHistory = 0.5;
+InitialAffectLoad = 0.5;
+Lucidity = 0.5;
+ImageStabilizationCapacity = 0.5;
+
+ImageValence = 0;
+ImageDominance = 0;
+ImageArousal = 0;
+
+MaxREMCyclesPerNight = 4;
+MaxHoursSleepPerNight = 8;
+IdealHoursSleepPerNight = 8;
+NormalSleepHour = 22;
+NTNMAffectLoadIncrement = 0.005;
+TNMAffectLoadIncrement = 0.01;
+FEAffectLoadDecrement = 0.01;
+
+FearExtinctionAttemptThreshold = 0.5;
+DandRFailureThreshold = 0.5;
+FearExtinctionFailureThreshold = 0.5;
+FearExtinctionCompletionThreshold = 0.5;
+PostNightmareSleepThreshold = 0.5;
+
+TreatmentDegreesOfControl = 0.5;
+TreatmentImagesSimilarToNM = 0.5;
+AdrenalineAntagonists = 0.5;
+TreatmentFrequency = 1;
+TreatmentType = 0;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594324367119</Id>
+					<Name><![CDATA[equals]]></Name>
+					<X>560</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[l1]]></Name>
+						<Type><![CDATA[List<Main.statechart_state>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[l2]]></Name>
+						<Type><![CDATA[List<Main.statechart_state>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[s]]></Name>
+						<Type><![CDATA[String]]></Type>
+					</Parameter>
+					<Body><![CDATA[int i = 0;
+
+while (i < l1.size() && i < l2.size() && l1.get(i).equals(l2.get(i))) {
+	i++;
+}
+
+if (i == l1.size() && i == l2.size()) {
+	return null;
+} else if (i == l1.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 1.\n";
+} else if (i == l2.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 2.\n";
+} else {
+	return s + "NOT EQUAL. This lists are equal up until index " + i + "\n";
+}]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594324967383</Id>
+					<Name><![CDATA[equals]]></Name>
+					<X>640</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[o1]]></Name>
+						<Type><![CDATA[double]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[o2]]></Name>
+						<Type><![CDATA[double]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[s]]></Name>
+						<Type><![CDATA[String]]></Type>
+					</Parameter>
+					<Body><![CDATA[return o1 == o2? "" : s;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594326635097</Id>
+					<Name><![CDATA[equalsDoubles]]></Name>
+					<X>720</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[l1]]></Name>
+						<Type><![CDATA[List<Double>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[l2]]></Name>
+						<Type><![CDATA[List<Double>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[s]]></Name>
+						<Type><![CDATA[String]]></Type>
+					</Parameter>
+					<Body><![CDATA[int i = 0;
+
+while (i < l1.size() && i < l2.size() && l1.get(i).equals(l2.get(i))) {
+	i++;
+}
+
+if (i == l1.size() && i == l2.size()) {
+	return "";
+} else if (i == l1.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 1.\n";
+} else if (i == l2.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 2.\n";
+} else {
+	return s + "NOT EQUAL. This lists are equal up until index " + i + "\n";
+}]]></Body>
+				</Function>
+			</Functions>
+
+			<Presentation>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594324367173</Id>
+					<Name><![CDATA[button_defaults]]></Name>
+					<X>40</X><Y>1640</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="200" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Reset to defaults]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Group>
+					<Id>1594324367177</Id>
+					<Name><![CDATA[group3]]></Name>
+					<X>674.5</X><Y>294.5</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594324367179</Id>
+					<Name><![CDATA[roundRectangle]]></Name>
+					<X>-134.5</X><Y>-203.98</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>167.109</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594324367181</Id>
+					<Name><![CDATA[text6]]></Name>
+					<X>-51.73</X><Y>-203.98</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Personal Factors]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594324367183</Id>
+					<Name><![CDATA[group4]]></Name>
+					<X>730</X><Y>310</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594324367185</Id>
+					<Name><![CDATA[roundRectangle1]]></Name>
+					<X>-190</X><Y>-40</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>120</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594324367187</Id>
+					<Name><![CDATA[text7]]></Name>
+					<X>-110</X><Y>-40</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Image Qualities]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594324367189</Id>
+					<Name><![CDATA[group5]]></Name>
+					<X>730</X><Y>440</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594324367191</Id>
+					<Name><![CDATA[roundRectangle2]]></Name>
+					<X>-190</X><Y>-50</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>230</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594324367193</Id>
+					<Name><![CDATA[text15]]></Name>
+					<X>-110</X><Y>-50</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Sleep Factors]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594324367195</Id>
+					<Name><![CDATA[group7]]></Name>
+					<X>740</X><Y>860</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594324367197</Id>
+					<Name><![CDATA[roundRectangle4]]></Name>
+					<X>-200</X><Y>-60</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>170</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594324367199</Id>
+					<Name><![CDATA[text8]]></Name>
+					<X>-110</X><Y>-60</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Treatment Parameters]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594324367201</Id>
+					<Name><![CDATA[group8]]></Name>
+					<X>630</X><Y>440</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594324367203</Id>
+					<Name><![CDATA[roundRectangle5]]></Name>
+					<X>-90</X><Y>190</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>160</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594324367205</Id>
+					<Name><![CDATA[text17]]></Name>
+					<X>-10</X><Y>190</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Thresholds]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Text>
+					<Id>1594324367207</Id>
+					<Name><![CDATA[text]]></Name>
+					<X>40</X><Y>20</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Run a test by resetting the parameters to defaults, then clicking a test to select that test to run.
+Then, run the simulation, and check the test output to see if the test passed.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594324367243</Id>
+					<Name><![CDATA[button_test10]]></Name>
+					<X>50</X><Y>130</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 0;
+TraumaHistory = 0;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 0.1;
+FEAffectLoadDecrement = 0.15;
+PostNightmareSleepThreshold = 0.2;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages),
+						"StateHistory ");
+	
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	StringBuilder sb = new StringBuilder();
+	
+	sb.append(equalsDoubles(root.HoursSleepHistory, Arrays.asList(8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 2.0, 2.0),
+		"HoursSleepHistory "));
+		
+	sb.append(equalsDoubles(root.REMPeriodsHistory, Arrays.asList(4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 0.0, 0.0),
+		"REMPeriodsHistory "));
+	
+	sb.append(equalsDoubles(root.NonTraumNMHistory, Arrays.asList(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0),
+		"NonTraumNMHistory "));
+		
+	sb.append(equalsDoubles(root.REMDeficitHistory, Arrays.asList(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0),
+		"REMDeficitHistory "));
+		
+	sb.append(equalsDoubles(root.SleepDeficitHistory, Arrays.asList(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 6.0 / 8.0, 6.0 / 8.0),
+		"SleepDeficitHistory "));
+	
+	sb.append(equals(root.HourOfDay, (22 + 30) % 24,
+		"HourOfDay "));
+		
+	sb.append(equals(root.HourOfRun, 30,
+		"HourOfRun "));
+	
+	errorMessage = sb.toString();
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[NonTraum NM Wake first NM, sleep next day]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594324367245</Id>
+					<Name><![CDATA[text13]]></Name>
+					<X>50</X><Y>190</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Testing the sleeping on next day.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594327244194</Id>
+					<Name><![CDATA[button_test12]]></Name>
+					<X>56</X><Y>246</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 1;
+TraumaHistory = 1;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 0.1;
+FEAffectLoadDecrement = 0.15;
+PostNightmareSleepThreshold = 0.2;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages),
+						"StateHistory ");
+	
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	StringBuilder sb = new StringBuilder();
+	
+	sb.append(equalsDoubles(root.HoursSleepHistory, Arrays.asList(8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 2.0, 0.0),
+		"HoursSleepHistory "));
+		
+	sb.append(equalsDoubles(root.REMPeriodsHistory, Arrays.asList(4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 0.0, 0.0),
+		"REMPeriodsHistory "));
+	
+	sb.append(equalsDoubles(root.NonTraumNMHistory, Arrays.asList(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0),
+		"NonTraumNMHistory "));
+		
+	sb.append(equalsDoubles(root.REMDeficitHistory, Arrays.asList(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0),
+		"REMDeficitHistory "));
+		
+	sb.append(equalsDoubles(root.SleepDeficitHistory, Arrays.asList(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 6.0 / 8, 1.0),
+		"SleepDeficitHistory "));
+	
+	sb.append(equals(root.HourOfDay, (22 + 30) % 24,
+		"HourOfDay "));
+		
+	sb.append(equals(root.HourOfRun, 30,
+		"HourOfRun "));
+	
+	errorMessage = sb.toString();
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[NonTraum NM Wake first NM, do not sleep next day]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594327244198</Id>
+					<Name><![CDATA[text16]]></Name>
+					<X>56</X><Y>306</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Testing the sleeping on next day.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+			<Parameters>			
+				<Parameter>
+					<ParameterName><![CDATA[AffectDistressTendency]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[AffectDistressTendency]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TraumaHistory]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TraumaHistory]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[FearExtinctionFailureThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[FearExtinctionFailureThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageValence]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageValence]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageArousal]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageArousal]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageDominance]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageDominance]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[InitialAffectLoad]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[InitialAffectLoad]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentDegreeOfControl]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentDegreesOfControl]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentImagesSimilarToNM]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentImagesSimilarToNM]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[AdrenalineAntagonists]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[AdrenalineAntagonists]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentFrequency]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentFrequency]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentType]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentType]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageStabilizationCapacity]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageStabilizationCapacity]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[FearExtinctionAttemptThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[FearExtinctionAttemptThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[DandRFailureThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[DandRFailureThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[MaxREMCyclesPerNight]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[MaxREMCyclesPerNight]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[MaxHoursSleepPerNight]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[MaxHoursSleepPerNight]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[IdealHoursSleepPerNight]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[IdealHoursSleepPerNight]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[FEAffectLoadDecrement]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[FEAffectLoadDecrement]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[PostNightmareSleepThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[PostNightmareSleepThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[NormalSleepHour]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[NormalSleepHour]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[NTNMAffectLoadIncrement]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[NTNMAffectLoadIncrement]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TNMAffectLoadIncrement]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TNMAffectLoadIncrement]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[Lucidity]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[Lucidity]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TimeInState]]></ParameterName>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ExperimentId]]></ParameterName>
+				</Parameter>
+			</Parameters>			
+			<PresentationProperties>
+				<EnableZoomAndPanning>true</EnableZoomAndPanning>
+				<ExecutionMode><![CDATA[virtualTime]]></ExecutionMode>
+				<Title><![CDATA[Disturbed Dreaming Model : Tests]]></Title>	
+				<EnableDeveloperPanel>true</EnableDeveloperPanel>
+				<ShowDeveloperPanelOnStart>false</ShowDeveloperPanelOnStart>
+				<RealTimeScale>0.1</RealTimeScale>
+			</PresentationProperties>
+			<ModelTimeProperties>
+				<StopOption><![CDATA[Stop at specified time]]></StopOption>
+				<InitialDate><![CDATA[1590192000000]]></InitialDate>	
+				<InitialTime><![CDATA[0.0]]></InitialTime>	
+				<FinalDate><![CDATA[1590300000000]]></FinalDate>	
+				<FinalTime><![CDATA[30.0]]></FinalTime>	
+			</ModelTimeProperties>
+		</SimulationExperiment>
+		<!--   =========   Simulation Experiment   ========  -->
+		<SimulationExperiment ActiveObjectClassId="1590253624667">
+			<Id>1594327371223</Id>
+			<Name><![CDATA[Tests_ManyNights]]></Name>
+			<ClientAreaTopLeft><X>0</X><Y>0</Y></ClientAreaTopLeft>
+			<Import><![CDATA[import java.util.function.*;]]></Import>
+			<CommandLineArguments><![CDATA[]]></CommandLineArguments>
+			<InitialSetupCode><![CDATA[setDefaults();]]></InitialSetupCode>
+			<MaximumMemory>512</MaximumMemory>
+			<RandomNumberGenerationType>fixedSeed</RandomNumberGenerationType>
+			<CustomGeneratorCode>new Random()</CustomGeneratorCode>
+			<AfterSimulationRunCode><![CDATA[root.DisplayTestResult(checkTestsFunction.apply(root));]]></AfterSimulationRunCode>
+			<SeedValue>1</SeedValue>
+			<SelectionModeForSimultaneousEvents>LIFO</SelectionModeForSimultaneousEvents>
+			<VmArgs><![CDATA[]]></VmArgs>
+			<LoadRootFromSnapshot>false</LoadRootFromSnapshot>
+			<Variables>
+				<Variable Class="PlainVariable">
+					<Id>1594327371233</Id>
+					<Name><![CDATA[AffectDistressTendency]]></Name>
+					<X>640</X><Y>120</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371235</Id>
+					<Name><![CDATA[TraumaHistory]]></Name>
+					<X>640</X><Y>150</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371237</Id>
+					<Name><![CDATA[FearExtinctionFailureThreshold]]></Name>
+					<X>630</X><Y>720</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371239</Id>
+					<Name><![CDATA[ImageValence]]></Name>
+					<X>640</X><Y>300</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371241</Id>
+					<Name><![CDATA[InitialAffectLoad]]></Name>
+					<X>640</X><Y>180</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371243</Id>
+					<Name><![CDATA[Lucidity]]></Name>
+					<X>640</X><Y>210</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371245</Id>
+					<Name><![CDATA[ImageStabilizationCapacity]]></Name>
+					<X>640</X><Y>240</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371247</Id>
+					<Name><![CDATA[ImageDominance]]></Name>
+					<X>640</X><Y>330</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371249</Id>
+					<Name><![CDATA[ImageArousal]]></Name>
+					<X>640</X><Y>360</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371251</Id>
+					<Name><![CDATA[MaxREMCyclesPerNight]]></Name>
+					<X>640</X><Y>420</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371253</Id>
+					<Name><![CDATA[MaxHoursSleepPerNight]]></Name>
+					<X>640</X><Y>450</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371255</Id>
+					<Name><![CDATA[IdealHoursSleepPerNight]]></Name>
+					<X>640</X><Y>480</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371257</Id>
+					<Name><![CDATA[NormalSleepHour]]></Name>
+					<X>640</X><Y>510</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371259</Id>
+					<Name><![CDATA[NTNMAffectLoadIncrement]]></Name>
+					<X>640</X><Y>540</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371261</Id>
+					<Name><![CDATA[FearExtinctionAttemptThreshold]]></Name>
+					<X>630</X><Y>660</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371263</Id>
+					<Name><![CDATA[DandRFailureThreshold]]></Name>
+					<X>630</X><Y>690</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371265</Id>
+					<Name><![CDATA[FearExtinctionCompletionThreshold]]></Name>
+					<X>630</X><Y>750</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371267</Id>
+					<Name><![CDATA[PostNightmareSleepThreshold]]></Name>
+					<X>630</X><Y>780</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371269</Id>
+					<Name><![CDATA[TreatmentDegreesOfControl]]></Name>
+					<X>640</X><Y>830</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371271</Id>
+					<Name><![CDATA[TreatmentImagesSimilarToNM]]></Name>
+					<X>640</X><Y>860</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371273</Id>
+					<Name><![CDATA[AdrenalineAntagonists]]></Name>
+					<X>640</X><Y>890</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371275</Id>
+					<Name><![CDATA[TreatmentFrequency]]></Name>
+					<X>640</X><Y>920</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371277</Id>
+					<Name><![CDATA[TreatmentType]]></Name>
+					<X>640</X><Y>950</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371279</Id>
+					<Name><![CDATA[TNMAffectLoadIncrement]]></Name>
+					<X>640</X><Y>570</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371281</Id>
+					<Name><![CDATA[FEAffectLoadDecrement]]></Name>
+					<X>640</X><Y>600</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[double]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1594327371283</Id>
+					<Name><![CDATA[checkTestsFunction]]></Name>
+					<X>560</X><Y>1320</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[Function<Main, TestResult>]]></Type>        
+						<InitialValue Class="CodeValue">
+							<Code><![CDATA[null;]]></Code>
+						</InitialValue>
+					</Properties>
+				</Variable>
+			</Variables>
+			<Functions>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>VOID</ReturnModificator>
+					<ReturnType><![CDATA[double]]></ReturnType>
+					<Id>1594327371225</Id>
+					<Name><![CDATA[setDefaults]]></Name>
+					<X>560</X><Y>1230</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[AffectDistressTendency = 0.5;
+TraumaHistory = 0.5;
+InitialAffectLoad = 0.5;
+Lucidity = 0.5;
+ImageStabilizationCapacity = 0.5;
+
+ImageValence = 0;
+ImageDominance = 0;
+ImageArousal = 0;
+
+MaxREMCyclesPerNight = 4;
+MaxHoursSleepPerNight = 8;
+IdealHoursSleepPerNight = 8;
+NormalSleepHour = 22;
+NTNMAffectLoadIncrement = 0.005;
+TNMAffectLoadIncrement = 0.01;
+FEAffectLoadDecrement = 0.01;
+
+FearExtinctionAttemptThreshold = 0.5;
+DandRFailureThreshold = 0.5;
+FearExtinctionFailureThreshold = 0.5;
+FearExtinctionCompletionThreshold = 0.5;
+PostNightmareSleepThreshold = 0.5;
+
+TreatmentDegreesOfControl = 0.5;
+TreatmentImagesSimilarToNM = 0.5;
+AdrenalineAntagonists = 0.5;
+TreatmentFrequency = 1;
+TreatmentType = 0;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594327371227</Id>
+					<Name><![CDATA[equals]]></Name>
+					<X>560</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[l1]]></Name>
+						<Type><![CDATA[List<Main.statechart_state>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[l2]]></Name>
+						<Type><![CDATA[List<Main.statechart_state>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[s]]></Name>
+						<Type><![CDATA[String]]></Type>
+					</Parameter>
+					<Body><![CDATA[int i = 0;
+
+while (i < l1.size() && i < l2.size() && l1.get(i).equals(l2.get(i))) {
+	i++;
+}
+
+if (i == l1.size() && i == l2.size()) {
+	return null;
+} else if (i == l1.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 1.\n";
+} else if (i == l2.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 2.\n";
+} else {
+	return s + "NOT EQUAL. This lists are equal up until index " + i + "\n";
+}]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594327371229</Id>
+					<Name><![CDATA[equals]]></Name>
+					<X>640</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[o1]]></Name>
+						<Type><![CDATA[double]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[o2]]></Name>
+						<Type><![CDATA[double]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[s]]></Name>
+						<Type><![CDATA[String]]></Type>
+					</Parameter>
+					<Body><![CDATA[return o1 == o2? "" : s;]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594327371231</Id>
+					<Name><![CDATA[equalsDoubles]]></Name>
+					<X>720</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[l1]]></Name>
+						<Type><![CDATA[List<Double>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[l2]]></Name>
+						<Type><![CDATA[List<Double>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[s]]></Name>
+						<Type><![CDATA[String]]></Type>
+					</Parameter>
+					<Body><![CDATA[int i = 0;
+
+while (i < l1.size() && i < l2.size() && l1.get(i).equals(l2.get(i))) {
+	i++;
+}
+
+if (i == l1.size() && i == l2.size()) {
+	return "";
+} else if (i == l1.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 1.\n";
+} else if (i == l2.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 2.\n";
+} else {
+	return s + "NOT EQUAL. This lists are equal up until index " + i + "\n";
+}]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1597079575710</Id>
+					<Name><![CDATA[equalsIntegers]]></Name>
+					<X>880</X><Y>1280</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Parameter>
+						<Name><![CDATA[l1]]></Name>
+						<Type><![CDATA[List<Integer>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[l2]]></Name>
+						<Type><![CDATA[List<Integer>]]></Type>
+					</Parameter>
+					<Parameter>
+						<Name><![CDATA[s]]></Name>
+						<Type><![CDATA[String]]></Type>
+					</Parameter>
+					<Body><![CDATA[int i = 0;
+
+while (i < l1.size() && i < l2.size() && l1.get(i).equals(l2.get(i))) {
+	i++;
+}
+
+if (i == l1.size() && i == l2.size()) {
+	return "";
+} else if (i == l1.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 1.\n";
+} else if (i == l2.size()) {
+	return s + "NOT EQUAL. The lists are equal up until the completion of list 2.\n";
+} else {
+	return s + "NOT EQUAL. This lists are equal up until index " + i + "\n";
+}]]></Body>
+				</Function>
+			</Functions>
+
+			<Presentation>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594327371285</Id>
+					<Name><![CDATA[button_defaults]]></Name>
+					<X>40</X><Y>1640</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="200" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[Reset to defaults]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Group>
+					<Id>1594327371287</Id>
+					<Name><![CDATA[group3]]></Name>
+					<X>674.5</X><Y>294.5</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594327371289</Id>
+					<Name><![CDATA[roundRectangle]]></Name>
+					<X>-134.5</X><Y>-203.98</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>167.109</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594327371291</Id>
+					<Name><![CDATA[text6]]></Name>
+					<X>-51.73</X><Y>-203.98</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Personal Factors]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594327371293</Id>
+					<Name><![CDATA[group4]]></Name>
+					<X>730</X><Y>310</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594327371295</Id>
+					<Name><![CDATA[roundRectangle1]]></Name>
+					<X>-190</X><Y>-40</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>120</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594327371297</Id>
+					<Name><![CDATA[text7]]></Name>
+					<X>-110</X><Y>-40</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Image Qualities]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594327371299</Id>
+					<Name><![CDATA[group5]]></Name>
+					<X>730</X><Y>440</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594327371301</Id>
+					<Name><![CDATA[roundRectangle2]]></Name>
+					<X>-190</X><Y>-50</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>230</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594327371303</Id>
+					<Name><![CDATA[text15]]></Name>
+					<X>-110</X><Y>-50</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Sleep Factors]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594327371305</Id>
+					<Name><![CDATA[group7]]></Name>
+					<X>740</X><Y>860</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594327371307</Id>
+					<Name><![CDATA[roundRectangle4]]></Name>
+					<X>-200</X><Y>-60</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>170</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594327371309</Id>
+					<Name><![CDATA[text8]]></Name>
+					<X>-110</X><Y>-60</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Treatment Parameters]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Group>
+					<Id>1594327371311</Id>
+					<Name><![CDATA[group8]]></Name>
+					<X>630</X><Y>440</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+
+			<Presentation>
+				<RoundedRectangle>
+					<Id>1594327371313</Id>
+					<Name><![CDATA[roundRectangle5]]></Name>
+					<X>-90</X><Y>190</Y>
+					<Label><X>10</X><Y>10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<ZHeight>10</ZHeight>
+					<LineWidth>1</LineWidth>
+					<LineColor>-16777216</LineColor>
+					<LineMaterial>null</LineMaterial>
+					<LineStyle>SOLID</LineStyle>
+					<Width>440</Width>
+					<Height>160</Height>
+					<Rotation>0.0</Rotation>
+					<FillColor>-1</FillColor>
+					<FillMaterial>null</FillMaterial>
+					<ArcRadius>10</ArcRadius>
+				</RoundedRectangle>
+				<Text>
+					<Id>1594327371315</Id>
+					<Name><![CDATA[text17]]></Name>
+					<X>-10</X><Y>190</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Thresholds]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+				</Group>
+				<Text>
+					<Id>1594327371317</Id>
+					<Name><![CDATA[text]]></Name>
+					<X>40</X><Y>20</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Run a test by resetting the parameters to defaults, then clicking a test to select that test to run.
+Then, run the simulation, and check the test output to see if the test passed.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+				<Control Type="Button">
+				 	<EmbeddedIcon>false</EmbeddedIcon>				
+					<Id>1594327371323</Id>
+					<Name><![CDATA[button_test12]]></Name>
+					<X>46</X><Y>76</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D3D</DrawMode>
+					<BasicProperties Width="330" Height="50">
+                        <EmbeddedIcon>false</EmbeddedIcon>	
+						<TextColor/>
+						<Enabled>true</Enabled>
+						<ActionCode><![CDATA[setDefaults();
+
+// Valence must be negative
+ImageValence = -1;
+
+// Manipulate control and fear
+AffectDistressTendency = 0.5;
+TraumaHistory = 0.2;
+ImageDominance = 1;
+ImageArousal = 1;
+
+// Set to high so DandR attempt happens
+DandRFailureThreshold = 1;
+
+// Initial affect load needs to be less than fear extinction threshold
+// and below the fear extinction complete threshold
+InitialAffectLoad = 0.8;
+FearExtinctionAttemptThreshold = 0.7; // A second attempt will not be made since affect load remains is below 0.7 after one decrement
+FearExtinctionCompletionThreshold = 0.7;
+FearExtinctionFailureThreshold = 0.1;
+FEAffectLoadDecrement = 0.15;
+PostNightmareSleepThreshold = 0.2;
+
+checkTestsFunction = root -> {
+	String errorMessage = equals(root.StateHistory, 
+		Arrays.asList(Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.EventMemoryImagesInSleep,
+						Main.RecontextualizedImages,
+						Main.AwakeImageAwareness,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages,
+						Main.WorkingMemoryImages),
+						"StateHistory ");
+	
+	
+	if (errorMessage != null) {
+		return new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	}
+	
+	StringBuilder sb = new StringBuilder();
+	
+	sb.append(equalsDoubles(root.HoursSleepHistory, Arrays.asList(8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0, 2.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0),
+		"HoursSleepHistory "));
+		
+	sb.append(equalsDoubles(root.REMPeriodsHistory, Arrays.asList(4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+		"REMPeriodsHistory "));
+	
+	sb.append(equalsDoubles(root.NonTraumNMHistory, Arrays.asList(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0),
+		"NonTraumNMHistory "));
+		
+	sb.append(equalsDoubles(root.REMDeficitHistory, Arrays.asList(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+		"REMDeficitHistory "));
+		
+	sb.append(equalsDoubles(root.SleepDeficitHistory, Arrays.asList(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 6.0 / 8, 1.0, 1.0, 1.0, 6.0 / 8, 6.0 / 8, 6.0 / 8),
+		"SleepDeficitHistory "));
+	
+	sb.append(equals(root.HourOfDay, (22 + 160) % 24,
+		"HourOfDay "));
+		
+	sb.append(equals(root.HourOfRun, 160,
+		"HourOfRun "));
+		
+	sb.append(equalsIntegers(root.MostRecentRegimenHistory, Arrays.asList(0, 2, 2, 2, 2, 2, 2, 2),
+		"MostRecentRegimen"));
+	
+	errorMessage = sb.toString();
+	return errorMessage.equals("")
+		? new TestResult(TestResult.TestResultState.PASS, "PASS")
+		: new TestResult(TestResult.TestResultState.FAIL, errorMessage);
+	
+}]]></ActionCode>
+					</BasicProperties>
+					<ExtendedProperties>
+						<Font Name="Dialog" Size="11" Style="0"/>
+						<LabelText><![CDATA[NonTraum NM Causes avoid sleep until giving into pressure]]></LabelText>
+					</ExtendedProperties>
+				</Control>
+				<Text>
+					<Id>1594327371325</Id>
+					<Name><![CDATA[text16]]></Name>
+					<X>46</X><Y>136</Y>
+					<Label><X>0</X><Y>-10</Y></Label>
+					<PublicFlag>true</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>false</ShowLabel>
+					<DrawMode>SHAPE_DRAW_2D</DrawMode>
+					<EmbeddedIcon>false</EmbeddedIcon>
+					<Z>0</Z>
+					<Rotation>0.0</Rotation>
+					<Color>-16777216</Color>
+					<Text><![CDATA[Person has nightmare which causes them to avoid sleep for a night.
+The next next, they succumb to sleep pressure, and the night after that,
+they avoid sleep again.]]></Text>
+					<Font>
+						<Name>SansSerif</Name>
+						<Size>10</Size>
+						<Style>0</Style>
+					</Font>
+					<Alignment>LEFT</Alignment>
+				</Text>
+			</Presentation>
+
+			<Parameters>			
+				<Parameter>
+					<ParameterName><![CDATA[AffectDistressTendency]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[AffectDistressTendency]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TraumaHistory]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TraumaHistory]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[FearExtinctionFailureThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[FearExtinctionFailureThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageValence]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageValence]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageArousal]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageArousal]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageDominance]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageDominance]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[InitialAffectLoad]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[InitialAffectLoad]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentDegreeOfControl]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentDegreesOfControl]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentImagesSimilarToNM]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentImagesSimilarToNM]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[AdrenalineAntagonists]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[AdrenalineAntagonists]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentFrequency]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentFrequency]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TreatmentType]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TreatmentType]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ImageStabilizationCapacity]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[ImageStabilizationCapacity]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[FearExtinctionAttemptThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[FearExtinctionAttemptThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[DandRFailureThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[DandRFailureThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[MaxREMCyclesPerNight]]></ParameterName>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[MaxHoursSleepPerNight]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[MaxHoursSleepPerNight]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[IdealHoursSleepPerNight]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[IdealHoursSleepPerNight]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[FEAffectLoadDecrement]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[FEAffectLoadDecrement]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[PostNightmareSleepThreshold]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[PostNightmareSleepThreshold]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[NormalSleepHour]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[NormalSleepHour]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[NTNMAffectLoadIncrement]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[NTNMAffectLoadIncrement]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TNMAffectLoadIncrement]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[TNMAffectLoadIncrement]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[Lucidity]]></ParameterName>
+					<ParameterValue Class="CodeValue">
+						<Code><![CDATA[Lucidity]]></Code>
+					</ParameterValue>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[TimeInState]]></ParameterName>
+				</Parameter>
+				<Parameter>
+					<ParameterName><![CDATA[ExperimentId]]></ParameterName>
+				</Parameter>
+			</Parameters>			
+			<PresentationProperties>
+				<EnableZoomAndPanning>true</EnableZoomAndPanning>
+				<ExecutionMode><![CDATA[virtualTime]]></ExecutionMode>
+				<Title><![CDATA[Disturbed Dreaming Model : Tests]]></Title>	
+				<EnableDeveloperPanel>true</EnableDeveloperPanel>
+				<ShowDeveloperPanelOnStart>false</ShowDeveloperPanelOnStart>
+				<RealTimeScale>0.1</RealTimeScale>
+			</PresentationProperties>
+			<ModelTimeProperties>
+				<StopOption><![CDATA[Stop at specified time]]></StopOption>
+				<InitialDate><![CDATA[1590192000000]]></InitialDate>	
+				<InitialTime><![CDATA[0.0]]></InitialTime>	
+				<FinalDate><![CDATA[1590768000000]]></FinalDate>	
+				<FinalTime><![CDATA[160.0]]></FinalTime>	
+			</ModelTimeProperties>
+		</SimulationExperiment>
+		<!--   =========  Parameter Variation Experiment   ========  -->
+		<ParamVariationExperiment ActiveObjectClassId="1590253624667">
+			<Id>1594395969866</Id>
+			<Name><![CDATA[ParametersVariation]]></Name>
+			<ClientAreaTopLeft><X>0</X><Y>0</Y></ClientAreaTopLeft>
+			<Import><![CDATA[import java.io.*;]]></Import>
+			<CommandLineArguments><![CDATA[]]></CommandLineArguments>
+			<InitialSetupCode><![CDATA[try {
+	outputWriter = new BufferedWriter(new FileWriter("ParametersVariationOutput.csv"));
+	outputWriter.write(GetHeaders() + "\n");
+	
+	outputWriterDaily = new BufferedWriter(new FileWriter("ParametersVariationOutputDaily.csv"));
+	outputWriterDaily.write(GetHeadersDaily() + "\n");
+} catch (IOException e) {
+	getEngine().error(e, "Error opening output file");
+}]]></InitialSetupCode>
+			<MaximumMemory>2048</MaximumMemory>
+			<RandomNumberGenerationType>fixedSeed</RandomNumberGenerationType>
+			<CustomGeneratorCode>new Random()</CustomGeneratorCode>
+			<BeforeSimulationRunCode><![CDATA[root.ExperimentId = "" + getCurrentIteration();]]></BeforeSimulationRunCode>
+			<AfterSimulationRunCode><![CDATA[if (root.DandRFailureThreshold > root.FearExtinctionFailureThreshold) {
+	try {
+		outputWriter.write(root.GetOutput() + "\n");
+		outputWriterDaily.write(root.GetDailyOutput());
+	} catch (IOException e) {
+		getEngine().error(e, "Error writing output");
+	}
+}]]></AfterSimulationRunCode>
+			<SeedValue>1</SeedValue>
+			<SelectionModeForSimultaneousEvents>LIFO</SelectionModeForSimultaneousEvents>
+			<VmArgs><![CDATA[]]></VmArgs>
+			<LoadRootFromSnapshot>false</LoadRootFromSnapshot>
+			<Variables>
+				<Variable Class="PlainVariable">
+					<Id>1594396073084</Id>
+					<Name><![CDATA[outputWriter]]></Name>
+					<X>280</X><Y>330</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[BufferedWriter]]></Type>        
+					</Properties>
+				</Variable>
+				<Variable Class="PlainVariable">
+					<Id>1597082394081</Id>
+					<Name><![CDATA[outputWriterDaily]]></Name>
+					<X>300</X><Y>450</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Properties SaveInSnapshot="true" Constant="false" AccessType="public" StaticVariable="false">
+						<Type><![CDATA[BufferedWriter]]></Type>        
+					</Properties>
+				</Variable>
+			</Variables>
+			<Functions>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1594396221768</Id>
+					<Name><![CDATA[GetHeaders]]></Name>
+					<X>280</X><Y>360</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[StringBuilder sb = new StringBuilder();
+
+sb.append("ExperimentId");
+sb.append(',');
+sb.append("AffectDistressTendency");
+sb.append(',');
+sb.append("TraumaHistory");
+sb.append(',');
+sb.append("InitialAffectLoad");
+sb.append(',');
+sb.append("Lucidity");
+sb.append(',');
+sb.append("ImageStabilizationCapacity");
+sb.append(',');
+sb.append("ImageValence");
+sb.append(',');
+sb.append("ImageDominance");
+sb.append(',');
+sb.append("ImageArousal");
+sb.append(',');
+sb.append("MaxREMCyclesPerNight");
+sb.append(',');
+sb.append("MaxHoursSleepPerNight");
+sb.append(',');
+sb.append("IdealHoursSleepPerNight");
+sb.append(',');
+sb.append("NormalSleepHour");
+sb.append(',');
+sb.append("NTNMAffectLoadIncrement");
+sb.append(',');
+sb.append("TNMAffectLoadIncrement");
+sb.append(',');
+sb.append("FEAffectLoadDecrement");
+sb.append(',');
+sb.append("FearExtinctionAttemptThreshold");
+sb.append(',');
+sb.append("DandRFailureThreshold");
+sb.append(',');
+sb.append("FearExtinctionFailureThreshold");
+sb.append(',');
+sb.append("PostNightmareSleepThreshold");
+sb.append(',');
+sb.append("TreatmentDegreeOfControl");
+sb.append(',');
+sb.append("TreatmentImagesSimilarToNM");
+sb.append(',');
+sb.append("AdrenalineAntagonists");
+sb.append(',');
+sb.append("TreatmentFrequency");
+sb.append(',');
+sb.append("TreatmentType");
+sb.append(',');
+sb.append("NightmareDistress");
+sb.append(',');
+sb.append("NightmareEffects");
+sb.append(',');
+sb.append("DASSAnxiety");
+sb.append(',');
+sb.append("MostRecentRegimen");
+
+
+return sb.toString();]]></Body>
+				</Function>
+				<Function AccessType="default" StaticFunction="false">
+					<ReturnModificator>RETURNS_VALUE</ReturnModificator>
+					<ReturnType><![CDATA[String]]></ReturnType>
+					<Id>1597082271200</Id>
+					<Name><![CDATA[GetHeadersDaily]]></Name>
+					<X>300</X><Y>480</Y>
+					<Label><X>10</X><Y>0</Y></Label>
+					<PublicFlag>false</PublicFlag>
+					<PresentationFlag>true</PresentationFlag>
+					<ShowLabel>true</ShowLabel>
+					<Body><![CDATA[StringBuilder sb = new StringBuilder();
+
+sb.append("ExperimentId");
+sb.append(',');
+sb.append("Night");
+sb.append(',');
+sb.append("NonTraumNM");
+sb.append(',');
+sb.append("TraumNM");
+sb.append(',');
+sb.append("SleepDeficit");
+sb.append(',');
+sb.append("REMDeficit");
+sb.append(',');
+sb.append("NightmareDistress");
+sb.append(',');
+sb.append("NightmareEffects");
+sb.append(',');
+sb.append("DASSAnxiety");
+sb.append(',');
+sb.append("MostRecentRegimen");
+
+return sb.toString();]]></Body>
+				</Function>
+			</Functions>
+
+
+			<AfterExperimentCode><![CDATA[try {
+	outputWriter.close();
+	outputWriterDaily.close();
+} catch (IOException e) {
+	getEngine().error(e, "Error closing output file");
+}]]></AfterExperimentCode>
+			<AllowParallelEvaluations>true</AllowParallelEvaluations>
+			<UseFreeformParameters>false</UseFreeformParameters>
+			<NumberOfRuns>10</NumberOfRuns>
+			<FreeformParamValue>	
+				<Id>1590272662305</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590274024200</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590274267533</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590347341808</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590347364670</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590347366159</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590349248375</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590349313043</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590349313049</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590445337740</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590445936951</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590445957713</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1590680120556</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591012739489</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591034183128</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591046767327</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591051655412</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591095647142</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591097977264</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591098449521</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591106138749</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591136318404</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591136346715</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1591193162221</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1594141524134</Id>
+			</FreeformParamValue>
+			<FreeformParamValue>	
+				<Id>1597080388010</Id>
+			</FreeformParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590272662305</Id>
+				<Type>RANGE</Type>
+				<From Class="CodeValue">
+					<Code><![CDATA[0]]></Code>
+				</From>
+				<To Class="CodeValue">
+					<Code><![CDATA[1]]></Code>
+				</To>
+				<Step Class="CodeValue">
+					<Code><![CDATA[0.1]]></Code>
+				</Step>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590274024200</Id>
+				<Type>RANGE</Type>
+				<From Class="CodeValue">
+					<Code><![CDATA[0]]></Code>
+				</From>
+				<To Class="CodeValue">
+					<Code><![CDATA[1]]></Code>
+				</To>
+				<Step Class="CodeValue">
+					<Code><![CDATA[0.1]]></Code>
+				</Step>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590274267533</Id>
+				<Type>FIXED</Type>
+				<Expression Class="CodeValue">
+					<Code><![CDATA[0.3]]></Code>
+				</Expression>
+				<From Class="CodeValue">
+					<Code><![CDATA[0]]></Code>
+				</From>
+				<To Class="CodeValue">
+					<Code><![CDATA[1]]></Code>
+				</To>
+				<Step Class="CodeValue">
+					<Code><![CDATA[0.01]]></Code>
+				</Step>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590347341808</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590347364670</Id>
+				<Type>RANGE</Type>
+				<From Class="CodeValue">
+					<Code><![CDATA[0]]></Code>
+				</From>
+				<To Class="CodeValue">
+					<Code><![CDATA[1]]></Code>
+				</To>
+				<Step Class="CodeValue">
+					<Code><![CDATA[0.1]]></Code>
+				</Step>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590347366159</Id>
+				<Type>RANGE</Type>
+				<From Class="CodeValue">
+					<Code><![CDATA[0]]></Code>
+				</From>
+				<To Class="CodeValue">
+					<Code><![CDATA[1]]></Code>
+				</To>
+				<Step Class="CodeValue">
+					<Code><![CDATA[0.1]]></Code>
+				</Step>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590349248375</Id>
+				<Type>RANGE</Type>
+				<From Class="CodeValue">
+					<Code><![CDATA[0.49]]></Code>
+				</From>
+				<To Class="CodeValue">
+					<Code><![CDATA[0.54]]></Code>
+				</To>
+				<Step Class="CodeValue">
+					<Code><![CDATA[0.01]]></Code>
+				</Step>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590349313043</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590349313049</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590445337740</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590445936951</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590445957713</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1590680120556</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591012739489</Id>
+				<Type>FIXED</Type>
+				<Expression Class="CodeValue">
+					<Code><![CDATA[0.5]]></Code>
+				</Expression>
+				<From Class="CodeValue">
+					<Code><![CDATA[0]]></Code>
+				</From>
+				<To Class="CodeValue">
+					<Code><![CDATA[1]]></Code>
+				</To>
+				<Step Class="CodeValue">
+					<Code><![CDATA[0.1]]></Code>
+				</Step>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591034183128</Id>
+				<Type>FIXED</Type>
+				<Expression Class="CodeValue">
+					<Code><![CDATA[0.4]]></Code>
+				</Expression>
+				<From Class="CodeValue">
+					<Code><![CDATA[0]]></Code>
+				</From>
+				<To Class="CodeValue">
+					<Code><![CDATA[1]]></Code>
+				</To>
+				<Step Class="CodeValue">
+					<Code><![CDATA[0.1]]></Code>
+				</Step>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591046767327</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591051655412</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591095647142</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591097977264</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591098449521</Id>
+				<Type>RANGE</Type>
+				<From Class="CodeValue">
+					<Code><![CDATA[0]]></Code>
+				</From>
+				<To Class="CodeValue">
+					<Code><![CDATA[1]]></Code>
+				</To>
+				<Step Class="CodeValue">
+					<Code><![CDATA[0.1]]></Code>
+				</Step>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591106138749</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591136318404</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591136346715</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1591193162221</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1594141524134</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<RangeVariationParamValue>	
+				<Id>1597080388010</Id>
+				<Type>FIXED</Type>
+			</RangeVariationParamValue>
+			<ModelTimeProperties>
+				<StopOption><![CDATA[Stop at specified time]]></StopOption>
+				<InitialDate><![CDATA[1590192000000]]></InitialDate>	
+				<InitialTime><![CDATA[0.0]]></InitialTime>	
+				<FinalDate><![CDATA[1592856000000]]></FinalDate>	
+				<FinalTime><![CDATA[740.0]]></FinalTime>	
+			</ModelTimeProperties>
+			<PresentationProperties>
+				<EnableZoomAndPanning>true</EnableZoomAndPanning>
+				<Title><![CDATA[Disturbed Dreaming Model : ParametersVariation]]></Title>
+				<EnableDeveloperPanel>true</EnableDeveloperPanel>
+				<ShowDeveloperPanelOnStart>false</ShowDeveloperPanelOnStart>
+			</PresentationProperties>
+			<ReplicationsProperties>
+				<UseReplication>false</UseReplication>
+				<FixedReplicationsNumber>true</FixedReplicationsNumber>
+				<ReplicationPerIteration>10</ReplicationPerIteration>
+				<MinimumReplication>2</MinimumReplication>
+				<MaximumReplication>10</MaximumReplication>
+				<ConfidenceLevel>LEVEL_80</ConfidenceLevel>
+				<ErrorPercent>0.5</ErrorPercent>
+				<ExpressionForConfidenceComputation><![CDATA[0]]></ExpressionForConfidenceComputation>
+			</ReplicationsProperties>
+		</ParamVariationExperiment>	
 	</Experiments>
+	<JavaClasses>
+		<!--   =========   Java Class   ========  -->
+		<JavaClass>
+			<Id>1594235420141</Id>
+			<Name><![CDATA[TestResult]]></Name>
+			<Text><![CDATA[/**
+ * TestResult
+ */	
+public class TestResult implements Serializable {
+
+	public final TestResultState state;
+	public final String errorMessage;
+	
+    /**
+     * Default constructor
+     */
+    public TestResult(TestResultState state, String errorMessage) {
+    	this.state = state;
+    	this.errorMessage = errorMessage;
+    }
+
+	@Override
+	public String toString() {
+		return super.toString();
+	}
+	
+	public enum TestResultState {
+			PASS, FAIL
+	}
+
+	/**
+	 * This number is here for model snapshot storing purpose<br>
+	 * It needs to be changed when this class gets changed
+	 */ 
+	private static final long serialVersionUID = 1L;
+
+}]]></Text>
+		</JavaClass>
+	</JavaClasses>
 	<ModelResources>
 		<Resource>
 			<Path><![CDATA[image.png]]></Path>


### PR DESCRIPTION
Many changes all squashed together.

Added tests.

Test: All tests pass.

Did some very simple validation. Needs more.

Clean up aesthetics.

Some logic cleanup.

1) Added FEPartial wake up.
2) Removed FearExtinctionComplete transition.
   FEPartial will complete from image in sleep, then
   depotentiate.
3) Removed FearExtinctionCompleteThreshold.

Test: All tests pass.

Threshold Parameters Variation & Added outputs

Also made deficits normalized.

Test: All tests pass.

Fix Perseveration for NightmareEffects output.

There was an issue where NightmareEffects output
would be inaccurate if the person was sleeping.

Fixed error with getting last week of values.

Only the most recent element from the history lists were
getting pulled.

Test: Tests Pass.

Fix issue with lastweek calculations using sum instead of avg.

We were getting NightmareEffect values > 1 because we
were not taking the average of deficits.

Setting up regimen tracking

Before run.

SimplifiedSweep